### PR TITLE
Address warnings in dockerfiles and composer files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_OPTIONS="--max_old_space_size=4096"
 # Listen / accept connections from all IP addresses.
 # NOTE: At this time it is only possible to run Docker container in Production mode
 # if you have a public URL. See https://github.com/DSpace/dspace-angular/issues/1485
-ENV NODE_ENV development
+ENV NODE_ENV=development
 RUN apk add tzdata
 RUN yarn build:prod
 RUN npm install pm2 -g

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -4,7 +4,7 @@
 # Test build:
 # docker build -f Dockerfile.dist -t dspace/dspace-angular:dspace-7_x-dist .
 
-FROM node:18-alpine as build
+FROM node:18-alpine AS build
 
 # Ensure Python and other build tools are available
 # These are needed to install some node modules, especially on linux/arm64
@@ -26,6 +26,6 @@ COPY --chown=node:node docker/dspace-ui.json /app/dspace-ui.json
 
 WORKDIR /app
 USER node
-ENV NODE_ENV production
+ENV NODE_ENV=production
 EXPOSE 4000
-CMD pm2-runtime start dspace-ui.json --json
+CMD ["pm2-runtime", "start", "dspace-ui.json", "--json"]

--- a/docker/cli.assetstore.yml
+++ b/docker/cli.assetstore.yml
@@ -12,7 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/cli.assetstore.yml
 #
 # Therefore, it should be kept in sync with that file
-version: "3.7"
 
 networks:
   dspacenet:

--- a/docker/cli.ingest.yml
+++ b/docker/cli.ingest.yml
@@ -12,7 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/cli.ingest.yml
 #
 # Therefore, it should be kept in sync with that file
-version: "3.7"
 
 services:
   dspace-cli:

--- a/docker/cli.yml
+++ b/docker/cli.yml
@@ -6,8 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: "3.7"
-
 services:
   dspace-cli:
     image: "${DOCKER_OWNER:-ufal}/dspace-cli:${DSPACE_VER:-dspace-7_x}"

--- a/docker/db.entities.yml
+++ b/docker/db.entities.yml
@@ -12,8 +12,6 @@
 # https://github.com/DSpace/DSpace/blob/main/dspace/src/main/docker-compose/db.entities.yml
 #
 # # Therefore, it should be kept in sync with that file
-version: "3.7"
-
 services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto:loadsql

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -10,7 +10,6 @@
 # This is used by our GitHub CI at .github/workflows/build.yml
 # It is based heavily on the Backend's Docker Compose:
 # https://github.com/DSpace/DSpace/blob/main/docker-compose.yml
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/docker/docker-compose-dist.yml
+++ b/docker/docker-compose-dist.yml
@@ -8,7 +8,6 @@
 
 # Docker Compose for running the DSpace Angular UI dist build
 # for previewing with the DSpace Demo site backend
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -10,7 +10,6 @@
 # This is based heavily on the docker-compose.yml that is available in the DSpace/DSpace
 # (Backend) at:
 # https://github.com/DSpace/DSpace/blob/main/docker-compose.yml
-version: '3.7'
 networks:
   dspacenet:
     # Due to the following specification, THIS FILE (docker-compose-rest.yml) must be last (if using several YMLs),

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,6 @@
 # http://www.dspace.org/license/
 #
 
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/docker/matomo-w-db.yml
+++ b/docker/matomo-w-db.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   db:
     image: mariadb


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Docker build gives
```
2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 27)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 31)
 ```
and  for Dockerfile.dist

```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 7)
```
I am not sure how to convert the args in the CMD in Dockerfile to an array, since it also contains redirect of output, so I skipped it.

For docker compose files I see

```
`version` is obsolete
````
### Reported issues
### Not-reported issues
## Analysis
## Problems

