### PR TITLE
creating docker-compose file useful for building clarin-dspace on MAC

### DIFF
--- a/docker/docker-compose-mac.yml
+++ b/docker/docker-compose-mac.yml
@@ -1,0 +1,11 @@
+services:
+  dspacesolr:
+    platform: linux/amd64
+  dspacedb:
+    platform: linux/amd64
+  dspace:
+    platform: linux/amd64
+  dspace-angular:
+    platform: linux/amd64
+  dspace-cli:
+    platform: linux/amd64


### PR DESCRIPTION
Created **docker-compose-mac.yml** file, that should be added to docker-compose commands in order to use
docker container with MAC M1, M2, M3, M4 processors.

Example:
`docker-compose --env-file .env -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f docker/docker-compose-mac.yml  pull`

