### PR TITLE
Issue 1235: show lastActive column in Access Control -> People table

### DIFF
--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -57,6 +57,7 @@
               <th scope="col">{{labelPrefix + 'table.id' | translate}}</th>
               <th scope="col">{{labelPrefix + 'table.name' | translate}}</th>
               <th scope="col">{{labelPrefix + 'table.email' | translate}}</th>
+              <th scope="col">{{labelPrefix + 'table.lastActive' | translate}}</th>
               <th>{{labelPrefix + 'table.edit' | translate}}</th>
             </tr>
             </thead>
@@ -66,6 +67,7 @@
               <td>{{epersonDto.eperson.id}}</td>
               <td>{{ dsoNameService.getName(epersonDto.eperson) }}</td>
               <td>{{epersonDto.eperson.email}}</td>
+              <td>{{epersonDto.eperson.lastActive | date:dateFormat:'UTC'}}</td>
               <td>
                 <div class="btn-group edit-field">
                   <button [routerLink]="getEditEPeoplePage(epersonDto.eperson.id)"

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -82,6 +82,11 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
    */
   subs: Subscription[] = [];
 
+  /**
+   * Date format used for ePerson lastActive table column
+   */
+  dateFormat = 'yyyy-MM-dd HH:mm:ss';
+
   constructor(private epersonService: EPersonDataService,
               private translateService: TranslateService,
               private notificationsService: NotificationsService,

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -311,6 +311,9 @@
   // "admin.access-control.epeople.table.email": "Email (exact)",
   // TODO Source message changed - Revise the translation
   "admin.access-control.epeople.table.email": "E-mail (přesný)",
+  // "admin.access-control.epeople.table.lastActive": "Last time active",
+  // TODO Source message changed - Revise the translation
+  "admin.access-control.epeople.table.lastActive": "Naposledy aktivní",
   // "admin.access-control.epeople.table.edit": "Edit",
   "admin.access-control.epeople.table.edit": "Upravit",
   // "admin.access-control.epeople.table.edit.buttons.edit": "Edit \"{{name}}\"",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -278,6 +278,8 @@
 
   "admin.access-control.epeople.table.email": "E-mail (exact)",
 
+  "admin.access-control.epeople.table.lastActive": "Last time active",
+
   "admin.access-control.epeople.table.edit": "Edit",
 
   "admin.access-control.epeople.table.edit.buttons.edit": "Edit \"{{name}}\"",


### PR DESCRIPTION
This is an implementation of https://github.com/ufal/clarin-dspace/issues/1235

added **lastActive** column to **Access Control -> People** table:

<img width="1387" height="601" alt="Screenshot 2025-07-28 at 12 25 03" src="https://github.com/user-attachments/assets/b130c90b-7230-4620-a93a-a7a2d34e4ae5" />

<img width="1345" height="508" alt="Screenshot 2025-07-28 at 12 25 23" src="https://github.com/user-attachments/assets/ed245b24-cae7-47de-b9a7-582f51bda850" />



