### PR TITLE
Issue 1247: show error message when user with no bitstream READ access wants to download file

### DIFF
--- a/src/app/bitstream-page/bitstream-page.module.ts
+++ b/src/app/bitstream-page/bitstream-page.module.ts
@@ -12,6 +12,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ClarinBitstreamDownloadPageComponent } from './clarin-bitstream-download-page/clarin-bitstream-download-page.component';
 import { ClarinLicenseAgreementPageComponent } from './clarin-license-agreement-page/clarin-license-agreement-page.component';
 import { ClarinBitstreamTokenExpiredComponent } from './clarin-bitstream-token-expired/clarin-bitstream-token-expired.component';
+import { ClarinBitstreamAuthorizationDeniedComponent } from './clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component';
 import { ClarinZipDownloadPageComponent } from './clarin-zip-download-page/clarin-zip-download-page.component';
 
 /**
@@ -35,6 +36,7 @@ import { ClarinZipDownloadPageComponent } from './clarin-zip-download-page/clari
     ClarinBitstreamDownloadPageComponent,
     ClarinLicenseAgreementPageComponent,
     ClarinBitstreamTokenExpiredComponent,
+    ClarinBitstreamAuthorizationDeniedComponent,
     ClarinZipDownloadPageComponent
   ]
 })

--- a/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.html
+++ b/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.html
@@ -1,0 +1,3 @@
+<div class="bg-clarin-red">
+  <h3>{{'clarin.bitstream.authorization.denied.message' | translate:{bitstream: (bitstream$ | async)?.name} }}</h3>
+</div>

--- a/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.scss
+++ b/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.scss
@@ -1,0 +1,5 @@
+.bg-clarin-red {
+  background-color: var(--lt-clarin-red-bg);
+  border-color: var(--lt-clarin-red-border);
+  color: var(--lt-clarin-red-text);
+}

--- a/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.spec.ts
+++ b/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { ClarinBitstreamAuthorizationDeniedComponent } from './clarin-bitstream-authorization-denied.component';
+
+describe('ClarinBitstreamAuthorizationDeniedComponent', () => {
+  // TODO uncomment and create tests
+  // let component: ClarinBitstreamAuthorizationDeniedComponent;
+  // let fixture: ComponentFixture<ClarinBitstreamAuthorizationDeniedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ClarinBitstreamAuthorizationDeniedComponent ]
+    })
+    .compileComponents();
+  });
+  // TODO uncomment and create tests
+  // beforeEach(() => {
+  //   fixture = TestBed.createComponent(ClarinBitstreamTokenExpiredComponent);
+  //   component = fixture.componentInstance;
+  //   fixture.detectChanges();
+  // });
+  //
+  // it('should create', () => {
+  //   expect(component).toBeTruthy();
+  // });
+});

--- a/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.ts
+++ b/src/app/bitstream-page/clarin-bitstream-authorization-denied/clarin-bitstream-authorization-denied.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Bitstream } from '../../core/shared/bitstream.model';
+
+/**
+ * This component shows error that the READ access to the bitstream is denied.
+ */
+@Component({
+  selector: 'ds-clarin-bitstream-authorization-denied',
+  templateUrl: './clarin-bitstream-authorization-denied.component.html',
+  styleUrls: ['./clarin-bitstream-authorization-denied.component.scss']
+})
+export class ClarinBitstreamAuthorizationDeniedComponent {
+
+  @Input()
+  bitstream$: Observable<Bitstream>;
+
+}

--- a/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.html
+++ b/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.html
@@ -10,4 +10,8 @@
     *ngIf="(downloadStatus | async) === 'DownloadTokenExpiredException'"
     [bitstream$]="bitstream$">
   </ds-clarin-bitstream-token-expired>
+  <ds-clarin-bitstream-authorization-denied
+    *ngIf="(downloadStatus | async) === 'Authorization denied'"
+    [bitstream$]="bitstream$">
+  </ds-clarin-bitstream-authorization-denied>
 </div>

--- a/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.ts
@@ -12,7 +12,8 @@ import { RequestService } from '../../core/data/request.service';
 import {
   DOWNLOAD_TOKEN_EXPIRED_EXCEPTION,
   HTTP_STATUS_UNAUTHORIZED,
-  MISSING_LICENSE_AGREEMENT_EXCEPTION
+  MISSING_LICENSE_AGREEMENT_EXCEPTION,
+  AUTHORIZATION_DENIED_EXCEPTION
 } from '../../core/shared/clarin/constants';
 import { RemoteDataBuildService } from '../../core/cache/builders/remote-data-build.service';
 import { hasValue, isEmpty, isNotEmpty, isNotNull, isUndefined } from '../../shared/empty.util';
@@ -166,6 +167,9 @@ export class ClarinBitstreamDownloadPageComponent implements OnInit {
             this.downloadStatus.next(DOWNLOAD_TOKEN_EXPIRED_EXCEPTION);
             return false;
           default:
+            if (requestEntry?.errorMessage && requestEntry?.errorMessage.startsWith(AUTHORIZATION_DENIED_EXCEPTION)) {
+              this.downloadStatus.next(AUTHORIZATION_DENIED_EXCEPTION);
+            }
             return false;
         }
       }

--- a/src/app/core/shared/clarin/constants.ts
+++ b/src/app/core/shared/clarin/constants.ts
@@ -1,6 +1,7 @@
 // Licenses
 export const MISSING_LICENSE_AGREEMENT_EXCEPTION = 'MissingLicenseAgreementException';
 export const DOWNLOAD_TOKEN_EXPIRED_EXCEPTION = 'DownloadTokenExpiredException';
+export const AUTHORIZATION_DENIED_EXCEPTION = 'Authorization denied';
 
 // Authorization
 export const HTTP_STATUS_UNAUTHORIZED = 401;

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1085,7 +1085,7 @@
   "clarin.license.agreement.notification.cannot.send.email": "Error: cannot send the email.",
   // "clarin.bitstream.expired.dtoken.message": "The download token is expired, you will be redirected to the download page.",
   "clarin.bitstream.expired.dtoken.message": "Platnost tokenu pro stahování vypršel, budete přesměrováni na stránku stahování.",
-  // "clarin.bitstream.authorization.denied.message": "Access to download "{{bitstream}}" file was denied by the bitstream resource policy.",
+  // "clarin.bitstream.authorization.denied.message": "Access to download \"{{bitstream}}\" file was denied by the bitstream resource policy.",
   // TODO Source message changed - Revise the translation
   "clarin.bitstream.authorization.denied.message": "Přístup ke stažení souboru \"{{bitstream}}\" byl zamítnut.",
   // "bitstream.download.page.back": "Back" ,

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1085,9 +1085,9 @@
   "clarin.license.agreement.notification.cannot.send.email": "Error: cannot send the email.",
   // "clarin.bitstream.expired.dtoken.message": "The download token is expired, you will be redirected to the download page.",
   "clarin.bitstream.expired.dtoken.message": "Platnost tokenu pro stahování vypršel, budete přesměrováni na stránku stahování.",
-  // "clarin.bitstream.authorization.denied.message": "The READ access to \"{{bitstream}}\" file was denied by the bitstream resource policy.",
+  // "clarin.bitstream.authorization.denied.message": "Access to download "{{bitstream}}" file was denied by the bitstream resource policy.",
   // TODO Source message changed - Revise the translation
-  "clarin.bitstream.authorization.denied.message": "Byl zamítnut přístup pro čtení k souboru: \"{{bitstream}}\".",
+  "clarin.bitstream.authorization.denied.message": "Přístup ke stažení souboru \"{{bitstream}}\" byl zamítnut.",
   // "bitstream.download.page.back": "Back" ,
   "bitstream.download.page.back": "Zpět",
   // "clarin.license.all-page.title": "Available Licenses",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1085,6 +1085,9 @@
   "clarin.license.agreement.notification.cannot.send.email": "Error: cannot send the email.",
   // "clarin.bitstream.expired.dtoken.message": "The download token is expired, you will be redirected to the download page.",
   "clarin.bitstream.expired.dtoken.message": "Platnost tokenu pro stahování vypršel, budete přesměrováni na stránku stahování.",
+  // "clarin.bitstream.authorization.denied.message": "The READ access to \"{{bitstream}}\" file was denied by the bitstream resource policy.",
+  // TODO Source message changed - Revise the translation
+  "clarin.bitstream.authorization.denied.message": "Byl zamítnut přístup pro čtení k souboru: \"{{bitstream}}\".",
   // "bitstream.download.page.back": "Back" ,
   "bitstream.download.page.back": "Zpět",
   // "clarin.license.all-page.title": "Available Licenses",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -726,7 +726,7 @@
 
   "clarin.bitstream.expired.dtoken.message": "The download token is expired, you will be redirected to the download page.",
 
-  "clarin.bitstream.authorization.denied.message": "The READ access to \"{{bitstream}}\" file was denied by the bitstream resource policy.",
+  "clarin.bitstream.authorization.denied.message": "Access to download \"{{bitstream}}\" file was denied by the bitstream resource policy.",
 
   "bitstream.download.page.back": "Back" ,
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -726,6 +726,8 @@
 
   "clarin.bitstream.expired.dtoken.message": "The download token is expired, you will be redirected to the download page.",
 
+  "clarin.bitstream.authorization.denied.message": "The READ access to \"{{bitstream}}\" file was denied by the bitstream resource policy.",
+
   "bitstream.download.page.back": "Back" ,
 
 


### PR DESCRIPTION
The fix:

In case, user has no READ access for bitstream, the following message is shown in UI on "Download file" click.
Example:

<img width="1224" height="186" alt="Screenshot 2025-07-31 at 10 13 17" src="https://github.com/user-attachments/assets/4a4fc9c7-cfca-4c75-a584-6f782d9f433a" />

or in Czech:

<img width="1223" height="167" alt="Screenshot 2025-07-31 at 10 13 32" src="https://github.com/user-attachments/assets/cd423fca-acde-43f2-bc9d-9afb0b40d80a" />

