### PR TITLE
issue 1072: implement file preview feature for .gz, .tar.gz, .xz, .tar.xz, .tgz and .7z archives

### DIFF
--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
@@ -16,7 +16,16 @@ import { hasValue } from '../../../../../shared/empty.util';
 import { AuthorizationDataService } from '../../../../../core/data/feature-authorization/authorization-data.service';
 import { AuthService } from '../../../../../core/auth/auth.service';
 
-const allowedPreviewFormats = ['text/plain', 'text/html', 'application/zip', 'application/x-tar'];
+const allowedPreviewFormats = [
+  'text/plain',
+  'text/html',
+  'application/zip',
+  'application/gzip',
+  'application/x-tar',
+  'application/x-gtar',
+  'application/x-xz',
+  'application/x-7z-compressed'
+];
 @Component({
   selector: 'ds-file-description',
   templateUrl: './file-description.component.html',
@@ -202,7 +211,7 @@ export class FileDescriptionComponent implements OnInit, OnDestroy {
   }
 
   isArchive(format: string): boolean {
-    return format === 'application/zip' || format === 'application/x-tar';
+    return allowedPreviewFormats.includes(format, 2);
   }
 
   hasNoPreview() {

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
@@ -16,9 +16,7 @@ import { hasValue } from '../../../../../shared/empty.util';
 import { AuthorizationDataService } from '../../../../../core/data/feature-authorization/authorization-data.service';
 import { AuthService } from '../../../../../core/auth/auth.service';
 
-const allowedPreviewFormats = [
-  'text/plain',
-  'text/html',
+const archiveFormats = [
   'application/zip',
   'application/gzip',
   'application/x-tar',
@@ -26,6 +24,9 @@ const allowedPreviewFormats = [
   'application/x-xz',
   'application/x-7z-compressed'
 ];
+
+const allowedPreviewFormats = archiveFormats.concat(['text/plain',  'text/html']);
+
 @Component({
   selector: 'ds-file-description',
   templateUrl: './file-description.component.html',
@@ -194,9 +195,6 @@ export class FileDescriptionComponent implements OnInit, OnDestroy {
     return this.fileInput?.format === 'text/html';
   }
 
-  /**
-   * Supported Preview formats are: `text/plain`, `text/html`, `application/zip`
-   */
   public couldPreview() {
     if (this.fileInput.canPreview === false) {
       return false;
@@ -211,7 +209,7 @@ export class FileDescriptionComponent implements OnInit, OnDestroy {
   }
 
   isArchive(format: string): boolean {
-    return allowedPreviewFormats.includes(format, 2);
+    return archiveFormats.includes(format);
   }
 
   hasNoPreview() {


### PR DESCRIPTION
Extended the File Preview feature for the following archive formats:
```
*.tar.gz
*.gz
*.tar.xz
*.xz
*.tgz
*.7z
```

See how it works:
<img width="1061" height="897" alt="Screenshot 2025-10-31 at 8 01 59" src="https://github.com/user-attachments/assets/a6e0b2bb-8300-42ca-b9dc-9a39f5525190" />



