### PR TITLE
13 links rely on color to be distinguishable on item view page

### DIFF
--- a/src/app/item-page/full/full-item-page.component.scss
+++ b/src/app/item-page/full/full-item-page.component.scss
@@ -16,13 +16,13 @@
 }
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
-.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far) {
+.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):not(.badge):not(.nav-link):not(.dropdown-item) {
   font-weight: 600 !important;
   font-style: italic !important;
 }
 
-.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):hover,
-.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):focus {
+.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):not(.badge):not(.nav-link):not(.dropdown-item):hover,
+.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):not(.badge):not(.nav-link):not(.dropdown-item):focus {
   text-decoration-thickness: 0.08em !important;
 }
 

--- a/src/app/item-page/full/full-item-page.component.scss
+++ b/src/app/item-page/full/full-item-page.component.scss
@@ -27,6 +27,6 @@
 }
 
 .full-item-info ::ng-deep a:focus-visible {
-  outline: 2px solid #1459c4 !important;
+  outline: 2px solid #{$primary} !important;
   outline-offset: 2px !important;
 }

--- a/src/app/item-page/full/full-item-page.component.scss
+++ b/src/app/item-page/full/full-item-page.component.scss
@@ -14,3 +14,21 @@
     max-width: none;
   }
 }
+
+// WCAG 1.4.1: Links must be distinguishable by more than color alone
+.full-item-info ::ng-deep a:not(.btn) {
+  text-decoration: underline !important;
+  text-decoration-thickness: 0.06em !important;
+  text-underline-offset: 0.15em !important;
+  text-decoration-skip-ink: auto !important;
+}
+
+.full-item-info ::ng-deep a:not(.btn):hover,
+.full-item-info ::ng-deep a:not(.btn):focus {
+  text-decoration-thickness: 0.08em !important;
+}
+
+.full-item-info ::ng-deep a:focus-visible {
+  outline: 2px solid #1459c4 !important;
+  outline-offset: 2px !important;
+}

--- a/src/app/item-page/full/full-item-page.component.scss
+++ b/src/app/item-page/full/full-item-page.component.scss
@@ -16,15 +16,15 @@
 }
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
-.full-item-info ::ng-deep a:not(.btn) {
+.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far) {
   text-decoration: underline !important;
   text-decoration-thickness: 0.06em !important;
   text-underline-offset: 0.15em !important;
   text-decoration-skip-ink: auto !important;
 }
 
-.full-item-info ::ng-deep a:not(.btn):hover,
-.full-item-info ::ng-deep a:not(.btn):focus {
+.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):hover,
+.full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):focus {
   text-decoration-thickness: 0.08em !important;
 }
 

--- a/src/app/item-page/full/full-item-page.component.scss
+++ b/src/app/item-page/full/full-item-page.component.scss
@@ -17,10 +17,8 @@
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
 .full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far) {
-  text-decoration: underline !important;
-  text-decoration-thickness: 0.06em !important;
-  text-underline-offset: 0.15em !important;
-  text-decoration-skip-ink: auto !important;
+  font-weight: 600 !important;
+  font-style: italic !important;
 }
 
 .full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):hover,

--- a/src/app/item-page/full/full-item-page.component.scss
+++ b/src/app/item-page/full/full-item-page.component.scss
@@ -17,16 +17,16 @@
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
 .full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):not(.badge):not(.nav-link):not(.dropdown-item) {
-  font-weight: 600 !important;
-  font-style: italic !important;
+  font-weight: 600;
+  font-style: italic;
 }
 
 .full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):not(.badge):not(.nav-link):not(.dropdown-item):hover,
 .full-item-info ::ng-deep a:not(.btn):not(.fab):not(.fas):not(.far):not(.badge):not(.nav-link):not(.dropdown-item):focus {
-  text-decoration-thickness: 0.08em !important;
+  text-decoration-thickness: 0.08em;
 }
 
 .full-item-info ::ng-deep a:focus-visible {
-  outline: 2px solid #{$primary} !important;
-  outline-offset: 2px !important;
+  outline: 2px solid #{$primary};
+  outline-offset: 2px;
 }

--- a/src/app/item-page/simple/item-page.component.scss
+++ b/src/app/item-page/simple/item-page.component.scss
@@ -43,3 +43,21 @@ pre {
   border-radius: 4px;
   white-space: pre-wrap;
 }
+
+// WCAG 1.4.1: Links must be distinguishable by more than color alone
+.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item) {
+  text-decoration: underline !important;
+  text-decoration-thickness: 0.06em !important;
+  text-underline-offset: 0.15em !important;
+  text-decoration-skip-ink: auto !important;
+}
+
+.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):hover,
+.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):focus {
+  text-decoration-thickness: 0.08em !important;
+}
+
+.item-page ::ng-deep a:focus-visible {
+  outline: 2px solid #1459c4 !important;
+  outline-offset: 2px !important;
+}

--- a/src/app/item-page/simple/item-page.component.scss
+++ b/src/app/item-page/simple/item-page.component.scss
@@ -45,15 +45,15 @@ pre {
 }
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
-.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item) {
+.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far) {
   text-decoration: underline !important;
   text-decoration-thickness: 0.06em !important;
   text-underline-offset: 0.15em !important;
   text-decoration-skip-ink: auto !important;
 }
 
-.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):hover,
-.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):focus {
+.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far):hover,
+.item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far):focus {
   text-decoration-thickness: 0.08em !important;
 }
 

--- a/src/app/item-page/simple/item-page.component.scss
+++ b/src/app/item-page/simple/item-page.component.scss
@@ -56,6 +56,6 @@ pre {
 }
 
 .item-page ::ng-deep a:focus-visible {
-  outline: 2px solid #1459c4 !important;
+  outline: 2px solid #{$primary} !important;
   outline-offset: 2px !important;
 }

--- a/src/app/item-page/simple/item-page.component.scss
+++ b/src/app/item-page/simple/item-page.component.scss
@@ -46,16 +46,16 @@ pre {
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
 .item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far) {
-  font-weight: 600 !important;
-  font-style: italic !important;
+  font-weight: 600;
+  font-style: italic;
 }
 
 .item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far):hover,
 .item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far):focus {
-  text-decoration-thickness: 0.08em !important;
+  text-decoration-thickness: 0.08em;
 }
 
 .item-page ::ng-deep a:focus-visible {
-  outline: 2px solid #{$primary} !important;
-  outline-offset: 2px !important;
+  outline: 2px solid #{$primary};
+  outline-offset: 2px;
 }

--- a/src/app/item-page/simple/item-page.component.scss
+++ b/src/app/item-page/simple/item-page.component.scss
@@ -46,10 +46,8 @@ pre {
 
 // WCAG 1.4.1: Links must be distinguishable by more than color alone
 .item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far) {
-  text-decoration: underline !important;
-  text-decoration-thickness: 0.06em !important;
-  text-underline-offset: 0.15em !important;
-  text-decoration-skip-ink: auto !important;
+  font-weight: 600 !important;
+  font-style: italic !important;
 }
 
 .item-page ::ng-deep a:not(.btn):not(.badge):not(.nav-link):not(.dropdown-item):not(.fab):not(.fas):not(.far):hover,


### PR DESCRIPTION
This pull request improves accessibility for links on both the full and simple item pages by ensuring they are visually distinguishable by more than just color, in compliance with WCAG 1.4.1 guidelines. The changes add underlines and focus outlines to links that are not styled as buttons or icons.

Accessibility improvements:

* Added CSS rules to `full-item-page.component.scss` so that links in `.full-item-info` (excluding buttons and icons) are underlined, with increased thickness on hover/focus, and a visible outline for keyboard focus.
* Added similar CSS rules to `item-page.component.scss` for links in `.item-page`, ensuring consistent accessibility enhancements for simple item pages.