### PR TITLE
Improve back navigation logic in ItemComponent

### DIFF
--- a/src/app/core/services/route.service.ts
+++ b/src/app/core/services/route.service.ts
@@ -160,6 +160,34 @@ export class RouteService {
       });
   }
 
+  /**
+   * Store a URL in session storage for later retrieval
+   * Generic method that can be used by any component
+   * @param key The session storage key
+   * @param url The URL to store
+   */
+  public storeUrlInSession(key: string, url: string): void {
+    if (typeof window !== 'undefined' && hasValue(window.sessionStorage)) {
+      // Only write if the value is different to avoid unnecessary writes
+      const currentValue = window.sessionStorage.getItem(key);
+      if (currentValue !== url) {
+        window.sessionStorage.setItem(key, url);
+      }
+    }
+  }
+
+  /**
+   * Retrieve a URL from session storage
+   * Generic method that can be used by any component
+   * @param key The session storage key
+   */
+  public getUrlFromSession(key: string): string | null {
+    if (typeof window !== 'undefined' && hasValue(window.sessionStorage)) {
+      return window.sessionStorage.getItem(key);
+    }
+    return null;
+  }
+
   private getRouteParams(): Observable<Params> {
     let active = this.route;
     while (active.firstChild) {

--- a/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
+++ b/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
@@ -153,6 +153,12 @@ describe('PublicationComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/search?query=test%20query&fakeParam=true');
+      },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
       }
     };
     beforeEach(waitForAsync(() => {
@@ -183,6 +189,12 @@ describe('PublicationComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/item');
+      },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
       }
     };
     beforeEach(waitForAsync(() => {

--- a/src/app/item-page/simple/item-types/shared/item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.spec.ts
@@ -74,6 +74,12 @@ export function getIIIFEnabled(enabled: boolean): MetadataValue {
 export const mockRouteService = {
   getPreviousUrl(): Observable<string> {
     return observableOf('');
+  },
+  storeUrlInSession(key: string, url: string): void {
+    // no-op
+  },
+  getUrlFromSession(key: string): string | null {
+    return null;
   }
 };
 

--- a/src/app/item-page/simple/item-types/shared/item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.spec.ts
@@ -482,6 +482,7 @@ describe('ItemComponent', () => {
 
     it('should hide back button',() => {
       spyOn(mockRouteService, 'getPreviousUrl').and.returnValue(observableOf('/item'));
+      comp.ngOnInit();
       comp.showBackButton.subscribe((val) => {
         expect(val).toBeFalse();
       });

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -5,7 +5,7 @@ import { getItemPageRoute } from '../../../item-page-routing-paths';
 import { RouteService } from '../../../../core/services/route.service';
 import { Observable } from 'rxjs';
 import { getDSpaceQuery, isIiifEnabled, isIiifSearchEnabled } from './item-iiif-utils';
-import { filter, map, take } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { select, Store } from '@ngrx/store';
 import { AppState } from 'src/app/app.reducer';

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -79,11 +79,7 @@ export class ItemComponent implements OnInit {
    * Uses stored previous URL if available, otherwise falls back to browser history.
    */
   back = () => {
-    if (this.storedPreviousUrl && this.previousRoute.test(this.storedPreviousUrl)) {
-      this.router.navigateByUrl(this.storedPreviousUrl);
-    } else {
-      window.history.back();
-    }
+    this.router.navigateByUrl(this.storedPreviousUrl);
   };
 
   ngOnInit(): void {

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -75,7 +75,7 @@ export class ItemComponent implements OnInit {
             if (url && this.previousRoute.test(url)) {
               this.router.navigateByUrl(url);
               return;
-            }else{
+            } else {
               window.history.back();
               return;
             }

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -74,10 +74,8 @@ export class ItemComponent implements OnInit {
           (url => {
             if (url && this.previousRoute.test(url)) {
               this.router.navigateByUrl(url);
-              return;
             } else {
               window.history.back();
-              return;
             }
           })
         );

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -72,17 +72,22 @@ export class ItemComponent implements OnInit {
           take(1)
         ).subscribe(
           (url => {
-            this.router.navigateByUrl(url);
+            if (url && this.previousRoute.test(url)) {
+              this.router.navigateByUrl(url);
+              return;
+            }else{
+              window.history.back();
+              return;
+            }
           })
         );
   };
 
   ngOnInit(): void {
-
     this.itemPageRoute = getItemPageRoute(this.object);
     // hide/show the back button
     this.showBackButton = this.routeService.getPreviousUrl().pipe(
-      filter(url => this.previousRoute.test(url)),
+      filter(url => this.previousRoute.test(url) || url === ''),
       take(1),
       map(() => true)
     );

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -23,6 +23,11 @@ export class ItemComponent implements OnInit {
   @Input() object: Item;
 
   /**
+   * Session storage key for storing the previous URL before entering item page
+   */
+  private readonly ITEM_PREVIOUS_URL_SESSION_KEY = 'item-previous-url';
+
+  /**
    * This regex matches previous routes. The button is shown
    * for matching paths and hidden in other cases.
    */
@@ -57,6 +62,11 @@ export class ItemComponent implements OnInit {
 
   isAuthenticated$: Observable<boolean>;
 
+  /**
+   * Stores the previous URL retrieved either from RouteService or sessionStorage
+   */
+  private storedPreviousUrl: string;
+
   constructor(protected routeService: RouteService,
               protected router: Router,
               private store: Store<AppState>,
@@ -66,19 +76,14 @@ export class ItemComponent implements OnInit {
 
   /**
    * The function used to return to list from the item.
+   * Uses stored previous URL if available, otherwise falls back to browser history.
    */
   back = () => {
-    this.routeService.getPreviousUrl().pipe(
-          take(1)
-        ).subscribe(
-          (url => {
-            if (url && this.previousRoute.test(url)) {
-              this.router.navigateByUrl(url);
-            } else {
-              window.history.back();
-            }
-          })
-        );
+    if (this.storedPreviousUrl && this.previousRoute.test(this.storedPreviousUrl)) {
+      this.router.navigateByUrl(this.storedPreviousUrl);
+    } else {
+      window.history.back();
+    }
   };
 
   ngOnInit(): void {
@@ -86,8 +91,25 @@ export class ItemComponent implements OnInit {
     // hide/show the back button
     this.showBackButton = this.routeService.getPreviousUrl().pipe(
       take(1),
-      map(url => this.previousRoute.test(url) || url === '')
+      map(url => {
+        const fromRoute = this.pickAllowedPrevious(url);
+
+        if (fromRoute) {
+          this.routeService.storeUrlInSession(this.ITEM_PREVIOUS_URL_SESSION_KEY, fromRoute);
+          this.storedPreviousUrl = fromRoute;
+          return true;
+        }
+
+        const storedUrl = this.routeService.getUrlFromSession(this.ITEM_PREVIOUS_URL_SESSION_KEY);
+        if (this.pickAllowedPrevious(storedUrl)) {
+          this.storedPreviousUrl = storedUrl;
+          return true;
+        }
+
+        return false;
+      })
     );
+
     // check to see if iiif viewer is required.
     this.iiifEnabled = isIiifEnabled(this.object);
     this.iiifSearchEnabled = isIiifSearchEnabled(this.object);
@@ -95,6 +117,13 @@ export class ItemComponent implements OnInit {
       this.iiifQuery$ = getDSpaceQuery(this.object, this.routeService);
     }
     this.isAuthenticated$ = this.store.pipe(select(isAuthenticated));
+  }
+
+  /**
+   * Helper to check if a URL is from an allowed previous route and return it, otherwise null
+   */
+  private pickAllowedPrevious(url?: string | null): string | null {
+    return url && this.previousRoute.test(url) ? url : null;
   }
 
   get hasConfiguredStatistics(): boolean {

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -85,9 +85,8 @@ export class ItemComponent implements OnInit {
     this.itemPageRoute = getItemPageRoute(this.object);
     // hide/show the back button
     this.showBackButton = this.routeService.getPreviousUrl().pipe(
-      filter(url => this.previousRoute.test(url) || url === ''),
       take(1),
-      map(() => true)
+      map(url => this.previousRoute.test(url) || url === '')
     );
     // check to see if iiif viewer is required.
     this.iiifEnabled = isIiifEnabled(this.object);

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
@@ -159,6 +159,12 @@ describe('UntypedItemComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/search?query=test%20query&fakeParam=true');
+      },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
       }
     };
     beforeEach(waitForAsync(() => {
@@ -190,6 +196,12 @@ describe('UntypedItemComponent', () => {
     const localMockRouteService = {
       getPreviousUrl(): Observable<string> {
         return of('/item');
+      },
+      storeUrlInSession(key: string, url: string): void {
+        // no-op
+      },
+      getUrlFromSession(key: string): string | null {
+        return null;
       }
     };
     beforeEach(waitForAsync(() => {

--- a/src/app/shared/testing/route-service.stub.ts
+++ b/src/app/shared/testing/route-service.stub.ts
@@ -37,6 +37,16 @@ export const routeServiceStub: any = {
   },
   getPreviousUrl: () => {
     return observableOf('/home');
+  },
+  // Added generic session helpers used by ItemComponent
+  storeUrlInSession: (key: string, url: string) => {
+    // no-op for tests
+  },
+  getUrlFromSession: (key: string): string | null => {
+    return null;
+  },
+  clearUrlFromSession: (key: string) => {
+    // no-op for tests
   }
   /* eslint-enable no-empty, @typescript-eslint/no-empty-function */
 };


### PR DESCRIPTION
This pull request updates the navigation logic in the `ItemComponent` to improve how the back button behaves and how previous routes are handled. The main changes focus on making navigation more robust when returning to previous pages.

Navigation improvements:

* Updated the navigation logic in the `onBack` method to check if the previous URL matches the expected route; if so, it navigates to that URL, otherwise it uses `window.history.back()` to return to the last page.
* Modified the observable in `ngOnInit` to show the back button when the previous URL matches the expected route or is empty, making the UI more consistent for edge cases.