### PR TITLE
89 wrong link on metadata static page

### DIFF
--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -11,27 +11,25 @@ import { environment } from '../../environments/environment';
 import { ClarinSafeHtmlPipe } from '../shared/utils/clarin-safehtml.pipe';
 
 describe('StaticPageComponent', () => {
-  let component: StaticPageComponent;
-  let fixture: ComponentFixture<StaticPageComponent>;
-
-  let htmlContentService: HtmlContentService;
-  let appConfig: any;
-
-  const htmlContent = '<div id="idShouldNotBeRemoved">TEST MESSAGE</div>';
-
-  beforeEach(async () => {
-    htmlContentService = jasmine.createSpyObj('htmlContentService', {
-      fetchHtmlContent: of(htmlContent),
-      getHmtlContentByPathAndLocale: Promise.resolve(htmlContent)
+  async function setupTest(html: string, restBase?: string) {
+    const htmlContentService = jasmine.createSpyObj('htmlContentService', {
+      fetchHtmlContent: of(html),
+      getHmtlContentByPathAndLocale: Promise.resolve(html)
     });
 
-    appConfig = Object.assign(environment, {
+    const appConfig = {
+      ...environment,
       ui: {
+        ...(environment as any).ui,
         namespace: 'testNamespace'
+      },
+      rest: {
+        ...(environment as any).rest,
+        baseUrl: restBase
       }
-    });
+    };
 
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       declarations: [ StaticPageComponent, ClarinSafeHtmlPipe ],
       imports: [
         TranslateModule.forRoot()
@@ -41,22 +39,65 @@ describe('StaticPageComponent', () => {
         { provide: Router, useValue: new RouterMock() },
         { provide: APP_CONFIG, useValue: appConfig }
       ]
-    });
+    }).compileComponents();
 
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(StaticPageComponent);
-    component = fixture.componentInstance;
-  });
+    const fixture = TestBed.createComponent(StaticPageComponent);
+    const component = fixture.componentInstance;
+    return { fixture, component, htmlContentService };
+  }
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(true).toBeTrue();
   });
 
   // Load `TEST MESSAGE`
   it('should load html file content', async () => {
+    const { component } = await setupTest('<div id="idShouldNotBeRemoved">TEST MESSAGE</div>');
     await component.ngOnInit();
     expect(component.htmlContent.value).toBe('<div id="idShouldNotBeRemoved">TEST MESSAGE</div>');
+  });
+
+  it('should rewrite OAI link with rest.baseUrl', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=ListSets">OAI</a>';
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/rest');
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const rewritten = 'https://api.example.org/server/oai/request?verb=ListSets';
+    expect(component.htmlContent.value).toContain(rewritten);
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(anchor.getAttribute('href')).toBe(rewritten);
+  });
+
+  it('should leave OAI link unchanged when rest.baseUrl is missing', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=Identify">OAI</a>';
+    const { fixture, component } = await setupTest(oaiHtml, undefined);
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.htmlContent.value).toContain('/server/oai/request?verb=Identify');
+  });
+
+  it('should avoid double slashes when rest.baseUrl ends with slash', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=ListRecords">OAI</a>';
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/rest/');
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.htmlContent.value).toContain('https://api.example.org/server/oai/request?verb=ListRecords');
+    expect(component.htmlContent.value).not.toContain('//server');
+  });
+
+  it('should leave content unchanged when no OAI link is present', async () => {
+    const otherHtml = '<a href="/server/other">Other</a>';
+    const { fixture, component } = await setupTest(otherHtml, 'https://api.example.org/rest');
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(component.htmlContent.value).toBe(otherHtml);
   });
 });

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -46,8 +46,9 @@ describe('StaticPageComponent', () => {
     return { fixture, component, htmlContentService };
   }
 
-  it('should create', () => {
-    expect(true).toBeTrue();
+  it('should create', async () => {
+    const { component } = await setupTest('<div>test</div>');
+    expect(component).toBeTruthy();
   });
 
   // Load `TEST MESSAGE`

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { StaticPageComponent } from './static-page.component';
 import { HtmlContentService } from '../shared/html-content.service';

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -28,8 +28,12 @@ export class StaticPageComponent implements OnInit {
     // Fetch html file name from the url path. `static/some_file.html`
     this.htmlFileName = this.getHtmlFileName();
 
-    const htmlContent = await this.htmlContentService.getHmtlContentByPathAndLocale(this.htmlFileName);
+    let htmlContent = await this.htmlContentService.getHmtlContentByPathAndLocale(this.htmlFileName);
     if (isNotEmpty(htmlContent)) {
+      const restBase = this.appConfig?.rest?.baseUrl;
+      const oaiUrl = restBase ? new URL('/server/oai', restBase + '/').href : '/server/oai';
+      htmlContent = htmlContent.replace(/href="\/server\/oai/gi, 'href="' + oaiUrl);
+
       this.htmlContent.next(htmlContent);
       return;
     }

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -31,7 +31,7 @@ export class StaticPageComponent implements OnInit {
     let htmlContent = await this.htmlContentService.getHmtlContentByPathAndLocale(this.htmlFileName);
     if (isNotEmpty(htmlContent)) {
       const restBase = this.appConfig?.rest?.baseUrl;
-      const oaiUrl = restBase ? new URL('/server/oai', restBase + '/').href : '/server/oai';
+      const oaiUrl = restBase ? new URL('/server/oai', restBase).href : '/server/oai';
       htmlContent = htmlContent.replace(/href="\/server\/oai/gi, 'href="' + oaiUrl);
 
       this.htmlContent.next(htmlContent);


### PR DESCRIPTION
This pull request refactors and expands the unit tests for the `StaticPageComponent` and updates the component logic to handle OAI links in the loaded HTML content. The main improvements include restructuring the test setup for better reusability and adding comprehensive tests for OAI link rewriting based on the `rest.baseUrl` configuration. Additionally, the component now rewrites OAI links in the HTML content to use the configured REST base URL, handling edge cases like trailing slashes.

**Testing improvements:**

* Refactored the test setup in `static-page.component.spec.ts` by introducing a reusable `setupTest` async function, reducing duplication and making tests clearer.
* Added new unit tests to verify OAI link rewriting, handling of missing or trailing slashes in `rest.baseUrl`, and ensuring non-OAI links remain unchanged.

**Component logic enhancements:**

* Updated `StaticPageComponent` to rewrite OAI links (`/server/oai/...`) in loaded HTML content to use the configured `rest.baseUrl`, ensuring correct link formation and avoiding double slashes.