### PR TITLE
Treat /home as previous route and add tests

### DIFF
--- a/src/app/item-page/simple/item-types/shared/item.component.spec.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.spec.ts
@@ -431,6 +431,7 @@ describe('ItemComponent', () => {
 
     const searchUrl = '/search?query=test&spc.page=2';
     const browseUrl = '/browse/title?scope=0cc&bbm.page=3';
+    const homeUrl = '/home';
     const recentSubmissionsUrl = '/collections/be7b8430-77a5-4016-91c9-90863e50583a?cp.page=3';
 
     beforeEach(waitForAsync(() => {
@@ -515,6 +516,32 @@ describe('ItemComponent', () => {
       comp.ngOnInit();
       comp.showBackButton.subscribe((val) => {
         expect(val).toBeTrue();
+      });
+    });
+
+    it('should show back button for home', () => {
+      spyOn(mockRouteService, 'getPreviousUrl').and.returnValue(observableOf(homeUrl));
+      comp.ngOnInit();
+      comp.showBackButton.subscribe((val) => {
+        expect(val).toBeTrue();
+      });
+    });
+
+    it('should prioritize home previous url over session fallback', () => {
+      const staleSessionUrl = searchUrl;
+      const getPreviousUrlSpy = spyOn(mockRouteService, 'getPreviousUrl').and.returnValue(observableOf(homeUrl));
+      const getUrlFromSessionSpy = spyOn(mockRouteService, 'getUrlFromSession').and.returnValue(staleSessionUrl);
+      const storeUrlInSessionSpy = spyOn(mockRouteService, 'storeUrlInSession');
+
+      comp.ngOnInit();
+      comp.showBackButton.subscribe((val) => {
+        expect(val).toBeTrue();
+        expect(getPreviousUrlSpy).toHaveBeenCalled();
+        expect(getUrlFromSessionSpy).not.toHaveBeenCalled();
+        expect(storeUrlInSessionSpy).toHaveBeenCalledWith('item-previous-url', homeUrl);
+
+        comp.back();
+        expect(router.navigateByUrl).toHaveBeenCalledWith(homeUrl);
       });
     });
   });

--- a/src/app/item-page/simple/item-types/shared/item.component.ts
+++ b/src/app/item-page/simple/item-types/shared/item.component.ts
@@ -31,7 +31,7 @@ export class ItemComponent implements OnInit {
    * This regex matches previous routes. The button is shown
    * for matching paths and hidden in other cases.
    */
-  previousRoute = /^(\/search|\/browse|\/collections|\/admin\/search|\/mydspace)/;
+  previousRoute = /^(\/home|\/search|\/browse|\/collections|\/admin\/search|\/mydspace)/;
 
   /**
    * Used to show or hide the back to results button in the view.


### PR DESCRIPTION
## Problem description

The "Back to Results" button on item detail pages incorrectly redirects to stale search/collection pages when accessed from Home page items, instead of returning to the Home page.

**User Journey:**
1. User browses Home page "What's New" section
2. User clicks an item to view details
3. User clicks "Back to Results" button
4. ❌ Redirected to old search/collection page instead of Home

**Root Cause:**
Session fallback logic introduced in commit `5dfb106f6f5` ("Improve back navigation logic in ItemComponent") excluded `/home` from the `previousRoute` regex allow-list. When navigating from Home, the component falls back to stale sessionStorage URLs from previous search/browse contexts instead of honoring the current Home context.

## Analysis

**Architectural Decision:**
- Include `/home` in allowed route regex
- Enforce current-context precedence over session fallback
- Preserve existing fallback capability for other contexts

**Validation:**
- ✅ Lint: All files pass (`yarn run lint --quiet`)
- ✅ Build: Production build successful (`yarn run build:prod`)
- ✅ Tests: 5,297 tests passed, 0 failures (`yarn run test:headless`)

