### PR TITLE
Add 'Add URL bitstream' feature to workspace items

### DIFF
--- a/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
+++ b/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
@@ -39,6 +39,14 @@
       {{'submission.workflow.generic.share-submission' | translate}}
     </span>
   </button>
+
+  <button type="button" id="{{'add_url_bitstream_' + object.id}}" class="btn btn-outline-primary mt-1 mb-3"
+          *ngIf="(canEditItem$ | async) && (canUseFileDownloader$ | async)"
+          [ngbTooltip]="'submission.workflow.generic.add-url-bitstream.tooltip' | translate"
+          [attr.aria-label]="'submission.workflow.generic.add-url-bitstream.tooltip' | translate"
+          (click)="$event.preventDefault();openAddBitstreamFromUrlModal(addBitstreamFromUrlModal)">
+    <i class="fa fa-link"></i> {{'submission.workflow.generic.add-url-bitstream' | translate}}
+  </button>
 </div>
 
 
@@ -57,5 +65,41 @@
       (click)="c('cancel')">{{'submission.general.discard.confirm.cancel' | translate}}</button>
     <button type="button" id="delete_confirm" class="btn btn-danger"
       (click)="c('ok')">{{'submission.general.discard.confirm.submit' | translate}}</button>
+  </div>
+</ng-template>
+
+<ng-template #addBitstreamFromUrlModal let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <div class="modal-title h4">{{'submission.workflow.generic.add-url-bitstream.modal.title' | translate}}</div>
+    <button type="button" class="close" aria-label="Close" (click)="d('cancel')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <div class="form-group">
+      <label for="bitstream-url-input">{{'submission.workflow.generic.add-url-bitstream.url.label' | translate}}</label>
+      <input id="bitstream-url-input" name="bitstream-url-input" class="form-control" type="url"
+             [(ngModel)]="bitstreamFromUrl" required>
+      <small class="text-danger" *ngIf="!bitstreamFromUrl?.trim()">
+        {{'submission.workflow.generic.add-url-bitstream.url.required' | translate}}
+      </small>
+    </div>
+    <div class="form-group">
+      <label for="bitstream-name-input">{{'submission.workflow.generic.add-url-bitstream.name.label' | translate}}</label>
+      <input id="bitstream-name-input" name="bitstream-name-input" class="form-control" type="text"
+             [placeholder]="'submission.workflow.generic.add-url-bitstream.name.placeholder' | translate"
+             [(ngModel)]="bitstreamName">
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="c('cancel')">
+      {{'submission.workflow.generic.add-url-bitstream.cancel' | translate}}
+    </button>
+    <button type="button" class="btn btn-primary"
+            [disabled]="!bitstreamFromUrl?.trim() || (processingAddFromUrl$ | async)"
+            (click)="addBitstreamFromUrl(c)">
+      <span *ngIf="(processingAddFromUrl$ | async)" class="spinner-border spinner-border-sm spinner-button" role="status" aria-hidden="true"></span>
+      {{'submission.workflow.generic.add-url-bitstream.submit' | translate}}
+    </button>
   </div>
 </ng-template>

--- a/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.spec.ts
+++ b/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.spec.ts
@@ -31,6 +31,8 @@ import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
 import { RemoteDataBuildService } from '../../../core/cache/builders/remote-data-build.service';
 import { HALEndpointServiceStub } from '../../testing/hal-endpoint-service.stub';
 import { getMockRemoteDataBuildService } from '../../mocks/remote-data-build.service.mock';
+import { ScriptDataService } from '../../../core/data/processes/script-data.service';
+import { getProcessDetailRoute } from '../../../process-page/process-page-routing.paths';
 
 let component: WorkspaceitemActionsComponent;
 let fixture: ComponentFixture<WorkspaceitemActionsComponent>;
@@ -41,6 +43,7 @@ let authorizationService;
 let authService;
 let halService: HALEndpointService;
 let rdbService: RemoteDataBuildService;
+let scriptDataService;
 
 const mockDataService = jasmine.createSpyObj('WorkspaceitemDataService', {
   delete: jasmine.createSpy('delete')
@@ -161,6 +164,11 @@ authService = jasmine.createSpyObj('authService', {
   getAuthenticatedUserFromStore: jasmine.createSpy('getAuthenticatedUserFromStore')
 });
 
+scriptDataService = jasmine.createSpyObj('scriptDataService', {
+  scriptWithNameExistsAndCanExecute: jasmine.createSpy('scriptWithNameExistsAndCanExecute'),
+  invoke: jasmine.createSpy('invoke')
+});
+
 halService = Object.assign(new HALEndpointServiceStub('url'));
 rdbService = getMockRemoteDataBuildService();
 
@@ -191,6 +199,7 @@ describe('WorkspaceitemActionsComponent', () => {
         { provide: AuthorizationDataService, useValue: authorizationService},
         { provide: HALEndpointService, useValue: halService },
         { provide: RemoteDataBuildService, useValue: rdbService },
+        { provide: ScriptDataService, useValue: scriptDataService },
         NgbModal
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -205,6 +214,7 @@ describe('WorkspaceitemActionsComponent', () => {
     component.object = mockObject;
     notificationsServiceStub = TestBed.inject(NotificationsService as any);
     (authService.getAuthenticatedUserFromStore as jasmine.Spy).and.returnValue(observableOf(ePersonMock));
+    (scriptDataService.scriptWithNameExistsAndCanExecute as jasmine.Spy).and.returnValue(observableOf(true));
     fixture.detectChanges();
   });
 
@@ -236,6 +246,61 @@ describe('WorkspaceitemActionsComponent', () => {
     const btn = fixture.debugElement.query(By.css('button[data-test="view-btn"]'));
 
     expect(btn).not.toBeNull();
+  });
+
+  it('should display add URL bitstream button when script is executable', () => {
+    const btn = fixture.debugElement.query(By.css('#add_url_bitstream_1234'));
+
+    expect(btn).not.toBeNull();
+  });
+
+  it('should not display add URL bitstream button when script is not executable', () => {
+    component.canUseFileDownloader$ = observableOf(false);
+    fixture.detectChanges();
+
+    const btn = fixture.debugElement.query(By.css('#add_url_bitstream_1234'));
+    expect(btn).toBeNull();
+  });
+
+  it('should invoke file-downloader with -u and -w and optional -n', () => {
+    const closeModal = jasmine.createSpy('closeModal');
+    const process = { processId: 101 } as any;
+    (scriptDataService.invoke as jasmine.Spy).and.returnValue(createSuccessfulRemoteDataObject$(process));
+
+    component.bitstreamFromUrl = ' https://example.org/file.pdf ';
+    component.bitstreamName = ' downloaded.pdf ';
+    component.addBitstreamFromUrl(closeModal);
+
+    expect(scriptDataService.invoke).toHaveBeenCalledWith('file-downloader', [
+      { name: '-u', value: 'https://example.org/file.pdf' },
+      { name: '-w', value: '1234' },
+      { name: '-n', value: 'downloaded.pdf' }
+    ], []);
+  });
+
+  it('should navigate to process detail and close modal on add from URL success', () => {
+    const closeModal = jasmine.createSpy('closeModal');
+    const router = TestBed.inject(Router);
+    spyOn(router, 'navigateByUrl').and.callThrough();
+    (scriptDataService.invoke as jasmine.Spy).and.returnValue(createSuccessfulRemoteDataObject$({ processId: 202 } as any));
+
+    component.bitstreamFromUrl = 'https://example.org/file.pdf';
+    component.addBitstreamFromUrl(closeModal);
+
+    expect(notificationsServiceStub.success).toHaveBeenCalled();
+    expect(closeModal).toHaveBeenCalledWith('ok');
+    expect(router.navigateByUrl).toHaveBeenCalledWith(getProcessDetailRoute('202'));
+  });
+
+  it('should show error notification on add from URL failure', () => {
+    const closeModal = jasmine.createSpy('closeModal');
+    (scriptDataService.invoke as jasmine.Spy).and.returnValue(createFailedRemoteDataObject$('Error', 500));
+
+    component.bitstreamFromUrl = 'https://example.org/file.pdf';
+    component.addBitstreamFromUrl(closeModal);
+
+    expect(notificationsServiceStub.error).toHaveBeenCalled();
+    expect(closeModal).not.toHaveBeenCalled();
   });
 
   describe('on discard confirmation', () => {

--- a/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.ts
+++ b/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.ts
@@ -22,6 +22,12 @@ import { getWorkspaceItemViewRoute } from '../../../workspaceitems-edit-page/wor
 import { GetRequest } from '../../../core/data/request.models';
 import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
 import { RemoteDataBuildService } from '../../../core/cache/builders/remote-data-build.service';
+import { ScriptDataService } from '../../../core/data/processes/script-data.service';
+import { ProcessParameter } from '../../../process-page/processes/process-parameter.model';
+import { Process } from '../../../process-page/processes/process.model';
+import { getProcessDetailRoute } from '../../../process-page/process-page-routing.paths';
+
+const FILE_DOWNLOADER_SCRIPT_NAME = 'file-downloader';
 
 /**
  * This component represents actions related to WorkspaceItem object.
@@ -57,6 +63,14 @@ export class WorkspaceitemActionsComponent extends MyDSpaceActionsComponent<Work
    */
   canEditItem$: Observable<boolean>;
 
+  canUseFileDownloader$: Observable<boolean>;
+
+  public processingAddFromUrl$ = new BehaviorSubject<boolean>(false);
+
+  public bitstreamFromUrl = '';
+
+  public bitstreamName = '';
+
   /**
    * Initialize instance variables
    *
@@ -79,6 +93,7 @@ export class WorkspaceitemActionsComponent extends MyDSpaceActionsComponent<Work
     public authorizationService: AuthorizationDataService,
     protected halService: HALEndpointService,
     protected rdbService: RemoteDataBuildService,
+    protected scriptDataService: ScriptDataService,
     ) {
     super(WorkspaceItem.type, injector, router, notificationsService, translate, searchService, requestService);
 
@@ -107,6 +122,8 @@ export class WorkspaceitemActionsComponent extends MyDSpaceActionsComponent<Work
   ngOnInit(): void {
     const activeEPerson$ = this.authService.getAuthenticatedUserFromStore();
 
+    this.canUseFileDownloader$ = this.scriptDataService.scriptWithNameExistsAndCanExecute(FILE_DOWNLOADER_SCRIPT_NAME);
+
     this.canEditItem$ = activeEPerson$.pipe(
       switchMap((eperson) => {
         return this.object?.item.pipe(
@@ -117,6 +134,55 @@ export class WorkspaceitemActionsComponent extends MyDSpaceActionsComponent<Work
           })
         ) as Observable<boolean>;
       }));
+  }
+
+  openAddBitstreamFromUrlModal(content): void {
+    this.bitstreamFromUrl = '';
+    this.bitstreamName = '';
+    this.processingAddFromUrl$.next(false);
+    this.modalService.open(content);
+  }
+
+  addBitstreamFromUrl(closeModal?: (value?: any) => void): void {
+    const normalizedUrl = this.bitstreamFromUrl?.trim();
+    const normalizedName = this.bitstreamName?.trim();
+
+    if (!normalizedUrl) {
+      return;
+    }
+
+    const parameters: ProcessParameter[] = [
+      { name: '-u', value: normalizedUrl },
+      { name: '-w', value: this.object.id }
+    ];
+
+    if (normalizedName) {
+      parameters.push({ name: '-n', value: normalizedName });
+    }
+
+    this.processingAddFromUrl$.next(true);
+    this.scriptDataService.invoke(FILE_DOWNLOADER_SCRIPT_NAME, parameters, [])
+      .pipe(getFirstCompletedRemoteData())
+      .subscribe((rd: RemoteData<Process>) => {
+        this.processingAddFromUrl$.next(false);
+        if (rd.hasSucceeded) {
+          this.notificationsService.success(
+            this.translate.get('process.new.notification.success.title'),
+            this.translate.get('process.new.notification.success.content')
+          );
+          if (closeModal) {
+            closeModal('ok');
+          }
+          if (rd.payload?.processId) {
+            this.router.navigateByUrl(getProcessDetailRoute(rd.payload.processId));
+          }
+        } else {
+          this.notificationsService.error(
+            this.translate.get('process.new.notification.error.title'),
+            this.translate.get('process.new.notification.error.content')
+          );
+        }
+      });
   }
 
   /**

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -9645,6 +9645,33 @@
   // "submission.workflow.generic.share-submission.tooltip": "Share submission",
   "submission.workflow.generic.share-submission.tooltip": "Sdílet příspěvek",
 
+  // "submission.workflow.generic.add-url-bitstream": "Add bitstream from URL",
+  "submission.workflow.generic.add-url-bitstream": "Přidat bitstream z URL",
+
+  // "submission.workflow.generic.add-url-bitstream.tooltip": "Add a new bitstream to this workspace item using a URL",
+  "submission.workflow.generic.add-url-bitstream.tooltip": "Přidat nový bitstream do této položky pracovního prostoru pomocí URL",
+
+  // "submission.workflow.generic.add-url-bitstream.modal.title": "Add bitstream from URL",
+  "submission.workflow.generic.add-url-bitstream.modal.title": "Přidat bitstream z URL",
+
+  // "submission.workflow.generic.add-url-bitstream.url.label": "File URL",
+  "submission.workflow.generic.add-url-bitstream.url.label": "URL souboru",
+
+  // "submission.workflow.generic.add-url-bitstream.url.required": "URL is required",
+  "submission.workflow.generic.add-url-bitstream.url.required": "URL je povinná",
+
+  // "submission.workflow.generic.add-url-bitstream.name.label": "Bitstream name (optional)",
+  "submission.workflow.generic.add-url-bitstream.name.label": "Název bitstreamu (volitelné)",
+
+  // "submission.workflow.generic.add-url-bitstream.name.placeholder": "e.g. image.png",
+  "submission.workflow.generic.add-url-bitstream.name.placeholder": "např. image.png",
+
+  // "submission.workflow.generic.add-url-bitstream.cancel": "Cancel",
+  "submission.workflow.generic.add-url-bitstream.cancel": "Zrušit",
+
+  // "submission.workflow.generic.add-url-bitstream.submit": "Add",
+  "submission.workflow.generic.add-url-bitstream.submit": "Přidat",
+
   // "submission.workflow.share-submission.email.successful": "The email with the share link has been sent successfully",
   "submission.workflow.share-submission.email.successful": "E-mail s odkazem na sdílení byl úspěšně odeslán",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6392,6 +6392,24 @@
 
   "submission.workflow.generic.share-submission.tooltip": "Share submission",
 
+  "submission.workflow.generic.add-url-bitstream": "Add bitstream from URL",
+
+  "submission.workflow.generic.add-url-bitstream.tooltip": "Add a new bitstream to this workspace item using a URL",
+
+  "submission.workflow.generic.add-url-bitstream.modal.title": "Add bitstream from URL",
+
+  "submission.workflow.generic.add-url-bitstream.url.label": "File URL",
+
+  "submission.workflow.generic.add-url-bitstream.url.required": "URL is required",
+
+  "submission.workflow.generic.add-url-bitstream.name.label": "Bitstream name (optional)",
+
+  "submission.workflow.generic.add-url-bitstream.name.placeholder": "e.g. image.png",
+
+  "submission.workflow.generic.add-url-bitstream.cancel": "Cancel",
+
+  "submission.workflow.generic.add-url-bitstream.submit": "Add",
+
   "submission.workflow.share-submission.email.successful": "The email with the share link has been sent successfully",
 
   "submission.workflow.share-submission.email.error": "Cannot send the email with share link",


### PR DESCRIPTION
Introduce an "Add bitstream from URL" action for workspace items: add a conditional button and modal UI to input a file URL and optional name. Implement component support using `ScriptDataService` to call the `file-downloader` script, manage processing state, show success/error notifications, and navigate to the created process detail on success. Add related unit tests (`scriptDataService` stub, UI visibility, invocation params, success/failure flows) and update English and Czech i18n strings.

## Problem description
Users could technically run the `file-downloader` script via the generic processes UI, but that flow is not contextual to workspace-item editing and is less discoverable for submitters.  
Issue #28 requires an indirect, workspace-item-local UX similar to existing contextual script-trigger patterns in the app.

## Analysis
- Implemented a workspace-item action with modal inputs:
  - required URL
  - optional bitstream name
  - filename placeholder hint (`e.g. image.png`) to communicate extension expectation
- Reused existing app architecture instead of introducing new backend/API logic:
  - script availability guard via `scriptWithNameExistsAndCanExecute`
  - script execution via `ScriptDataService.invoke('file-downloader', ...)`
  - standard process success/error notifications
  - navigation to process detail using existing route helper
- Added focused unit coverage for:
  - action visibility (available/unavailable script)
  - invocation payload mapping (`-u`, `-w`, optional `-n`)
  - success and failure handling paths
- Localization updated in both EN and CS for all new UI strings (including placeholder).


## Validation
- `yarn run test:headless --include='**workspaceitem-actions.component.spec.ts'` ✅ PASS (`13/13`)
- `yarn run lint --quiet` ✅ PASS
- `yarn run build:prod` ✅ PASS (with pre-existing custom-theme unused-file warnings only)

### Copilot review
- [x] Requested review from Copilot