### PR TITLE
Refactor license contract page and improve collection display

### DIFF
--- a/src/app/license-contract-page/license-contract-page.component.html
+++ b/src/app/license-contract-page/license-contract-page.component.html
@@ -1,13 +1,44 @@
 <div class="container">
-  <div class="card" *ngVar="(collectionRD$ | async)?.payload as collection">
+  <div class="card">
     <h5 class="card-header">{{'contract.message.distribution-license-agreement' | translate}}</h5>
-    <div class="card-body">
-      <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses">
-          <h3>{{collection?.name}}</h3>
-            <textarea class="form-control" cols="0" id="cz_cuni_mff_ufal_ContractPage_field_license_text_18"
-                      name="license_text_18" readonly
-                      rows="34">{{(licenseRD$ | async)?.payload?.text}}</textarea>
+    <ng-container *ngIf="!isListMode(); else authorizedCollectionsTemplate">
+      <div class="card-body" *ngVar="(collectionRD$ | async)?.payload as collection">
+        <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses">
+            <h3>{{collection?.name}}</h3>
+              <textarea class="form-control" cols="0" id="cz_cuni_mff_ufal_ContractPage_field_license_text_18"
+                        name="license_text_18" readonly
+                        rows="34">{{(licenseRD$ | async)?.payload?.text}}</textarea>
+        </div>
       </div>
-    </div>
+    </ng-container>
   </div>
 </div>
+
+<ng-template #authorizedCollectionsTemplate>
+  <ng-container *ngVar="(collectionsRD$ | async) as collectionsRD">
+    <ds-pagination *ngIf="collectionsRD?.payload?.totalElements > 0 || collectionsRD?.payload?.page?.length > 0"
+                   [paginationOptions]="pageConfig"
+                   [collectionSize]="collectionsRD?.payload?.totalElements"
+                   [hideGear]="true"
+                   [hidePagerWhenSinglePage]="true">
+      <div class="card-body" *ngFor="let collection of collectionsRD?.payload?.page">
+        <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses">
+          <h3>{{collection?.name}}</h3>
+          <textarea class="form-control"
+                    cols="0"
+                    readonly
+                    rows="34">{{(collection?.license | async)?.payload?.text}}</textarea>
+        </div>
+      </div>
+    </ds-pagination>
+
+    <div *ngIf="collectionsRD?.payload?.totalElements === 0 || collectionsRD?.payload?.page?.length === 0"
+         class="alert alert-info mt-3"
+         role="alert">
+      {{'collection.select.empty' | translate}}
+    </div>
+
+    <ds-error *ngIf="collectionsRD?.hasFailed" message="{{'error.collections' | translate}}"></ds-error>
+    <ds-themed-loading *ngIf="!collectionsRD || collectionsRD?.isLoading" message="{{'loading.collections' | translate}}"></ds-themed-loading>
+  </ng-container>
+</ng-template>

--- a/src/app/license-contract-page/license-contract-page.component.html
+++ b/src/app/license-contract-page/license-contract-page.component.html
@@ -21,8 +21,8 @@
                    [collectionSize]="collectionsRD?.payload?.totalElements"
                    [hideGear]="true"
                    [hidePagerWhenSinglePage]="true">
-      <div class="card-body" *ngFor="let collection of collectionsRD?.payload?.page">
-        <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses">
+      <div class="card-body" *ngFor="let collection of collectionsRD?.payload?.page; let i = index">
+        <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses_{{i}}">
           <h3>{{collection?.name}}</h3>
           <textarea class="form-control"
                     cols="0"

--- a/src/app/license-contract-page/license-contract-page.component.html
+++ b/src/app/license-contract-page/license-contract-page.component.html
@@ -2,14 +2,18 @@
   <div class="card">
     <h5 class="card-header">{{'contract.message.distribution-license-agreement' | translate}}</h5>
     <ng-container *ngIf="!isListMode(); else authorizedCollectionsTemplate">
-      <div class="card-body" *ngVar="(collectionRD$ | async)?.payload as collection">
-        <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses">
-            <h3>{{collection?.name}}</h3>
-              <textarea class="form-control" cols="0" id="cz_cuni_mff_ufal_ContractPage_field_license_text_18"
-                        name="license_text_18" readonly
-                        rows="34">{{(licenseRD$ | async)?.payload?.text}}</textarea>
+      <ng-container *ngVar="(collectionRD$ | async) as collectionRD">
+        <ds-error *ngIf="collectionRD?.hasFailed" message="{{'error.collection' | translate}}"></ds-error>
+        <ds-themed-loading *ngIf="!collectionRD || collectionRD?.isLoading" message="{{'loading.collection' | translate}}"></ds-themed-loading>
+        <div class="card-body" *ngIf="collectionRD?.payload">
+          <div class=" well" id="cz_cuni_mff_ufal_ContractPage_div_licenses">
+            <h3>{{collectionRD?.payload?.name}}</h3>
+            <textarea class="form-control" cols="0" id="cz_cuni_mff_ufal_ContractPage_field_license_text_18"
+                      name="license_text_18" readonly
+                      rows="34">{{(licenseRD$ | async)?.payload?.text}}</textarea>
+          </div>
         </div>
-      </div>
+      </ng-container>
     </ng-container>
   </div>
 </div>

--- a/src/app/license-contract-page/license-contract-page.component.spec.ts
+++ b/src/app/license-contract-page/license-contract-page.component.spec.ts
@@ -18,6 +18,7 @@ import { FindListOptions } from '../core/data/find-list-options.model';
 import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
 import { SortDirection, SortOptions } from '../core/cache/models/sort-options.model';
 
+/* eslint-disable @angular-eslint/directive-selector */
 @Directive({
   selector: '[ngVar]'
 })

--- a/src/app/license-contract-page/license-contract-page.component.spec.ts
+++ b/src/app/license-contract-page/license-contract-page.component.spec.ts
@@ -6,7 +6,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { Directive, Input, NO_ERRORS_SCHEMA } from '@angular/core';
-import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
 import { CollectionDataService } from '../core/data/collection-data.service';
 import { Collection } from '../core/shared/collection.model';
 import { License } from '../core/shared/license.model';
@@ -133,6 +133,7 @@ describe('LicenseContractPageComponent', () => {
 
   beforeEach(() => {
     routeStub.snapshot.queryParams = { ...paramObject };
+    collectionService.findById.and.returnValue(createSuccessfulRemoteDataObject$(collection));
     collectionService.findById.calls.reset();
     collectionService.getAuthorizedCollection.calls.reset();
     paginationService.getFindListOptions.calls.reset();
@@ -152,6 +153,18 @@ describe('LicenseContractPageComponent', () => {
 
   it('should load licenseRD$', () => {
     expect(component.licenseRD$.value.payload).toEqual(singleCollectionLicense);
+  });
+
+  it('should set hasFailed on collectionRD$ when collectionId is bogus', () => {
+    collectionService.findById.and.returnValue(createFailedRemoteDataObject$('Not Found', 404));
+    collectionService.findById.calls.reset();
+
+    const failFixture = TestBed.createComponent(LicenseContractPageComponent);
+    const failComponent = failFixture.componentInstance;
+    failFixture.detectChanges();
+
+    expect(collectionService.findById).toHaveBeenCalled();
+    expect(failComponent.collectionRD$.value.hasFailed).toBeTrue();
   });
 
   it('should load authorized collections when collectionId is missing', () => {

--- a/src/app/license-contract-page/license-contract-page.component.spec.ts
+++ b/src/app/license-contract-page/license-contract-page.component.spec.ts
@@ -5,21 +5,33 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { ActivatedRoute, Params } from '@angular/router';
+import { Directive, Input, NO_ERRORS_SCHEMA } from '@angular/core';
 import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
 import { CollectionDataService } from '../core/data/collection-data.service';
 import { Collection } from '../core/shared/collection.model';
-import { mockLicenseRD$ } from '../shared/testing/clarin-license-mock';
-import { take } from 'rxjs/operators';
-import { getFirstCompletedRemoteData } from '../core/shared/operators';
+import { License } from '../core/shared/license.model';
+import { PaginationService } from '../core/pagination/pagination.service';
+import { buildPaginatedList } from '../core/data/paginated-list.model';
+import { PageInfo } from '../core/shared/page-info.model';
+import { of as observableOf } from 'rxjs';
+import { FindListOptions } from '../core/data/find-list-options.model';
+import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
+import { SortDirection, SortOptions } from '../core/cache/models/sort-options.model';
+
+@Directive({
+  selector: '[ngVar]'
+})
+class MockNgVarDirective {
+  @Input() ngVar: unknown;
+}
 
 describe('LicenseContractPageComponent', () => {
   let component: LicenseContractPageComponent;
   let fixture: ComponentFixture<LicenseContractPageComponent>;
 
-  let collection: Collection;
-
   let routeStub: any;
-  let collectionService: CollectionDataService;
+  let collectionService: jasmine.SpyObj<CollectionDataService>;
+  let paginationService: jasmine.SpyObj<PaginationService>;
 
   const paramCollectionId = 'collectionId';
   const paramCollectionIdValue = '1';
@@ -27,23 +39,72 @@ describe('LicenseContractPageComponent', () => {
   const paramObject: Params = {};
   paramObject[paramCollectionId] = paramCollectionIdValue;
 
-  collection = Object.assign(new Collection(), {
+  const singleCollectionLicense = Object.assign(new License(), {
+    text: 'Single collection license text'
+  });
+
+  const collection = Object.assign(new Collection(), {
     uuid: 'fake-collection-id',
+    name: 'Single collection',
     _links: {
       self: {href: 'collection-selflink'},
       license: {href: 'license-link'}
     },
-    license: mockLicenseRD$
+    license: createSuccessfulRemoteDataObject$(singleCollectionLicense)
   });
+
+  const secondCollectionLicense = Object.assign(new License(), {
+    text: 'Second collection license text'
+  });
+
+  const authorizedCollections = [
+    collection,
+    Object.assign(new Collection(), {
+      uuid: 'second-collection-id',
+      name: 'Second collection',
+      _links: {
+        self: { href: 'second-collection-selflink' },
+        license: { href: 'second-license-link' }
+      },
+      license: createSuccessfulRemoteDataObject$(secondCollectionLicense)
+    })
+  ];
+
+  const authorizedCollectionsRD$ = createSuccessfulRemoteDataObject$(
+    buildPaginatedList(
+      new PageInfo({
+        currentPage: 1,
+        elementsPerPage: 10,
+        totalElements: authorizedCollections.length,
+        totalPages: 1
+      }),
+      authorizedCollections
+    )
+  );
 
   routeStub = {
     snapshot: {
-      queryParams: paramObject,
+      queryParams: { ...paramObject },
     }
   };
 
-  collectionService = jasmine.createSpyObj('collectionService', {
-    findById: createSuccessfulRemoteDataObject$(collection)
+  collectionService = jasmine.createSpyObj<CollectionDataService>('collectionService', {
+    findById: createSuccessfulRemoteDataObject$(collection),
+    getAuthorizedCollection: authorizedCollectionsRD$
+  });
+
+  paginationService = jasmine.createSpyObj<PaginationService>('paginationService', {
+    getFindListOptions: observableOf(Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 10
+    })),
+    getCurrentPagination: observableOf(Object.assign(new PaginationComponentOptions(), {
+      currentPage: 1,
+      pageSize: 10,
+      pageSizeOptions: [1, 5, 10, 20, 40, 60, 80, 100],
+    })),
+    getCurrentSort: observableOf(new SortOptions('name', SortDirection.ASC)),
+    clearPagination: undefined
   });
 
   beforeEach(async () => {
@@ -53,20 +114,28 @@ describe('LicenseContractPageComponent', () => {
         CommonModule,
         FormsModule,
         ReactiveFormsModule,
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
       ],
       declarations: [
-        LicenseContractPageComponent
+        LicenseContractPageComponent,
+        MockNgVarDirective
       ],
       providers: [
         { provide: ActivatedRoute, useValue: routeStub },
         { provide: CollectionDataService, useValue: collectionService },
-      ]
+        { provide: PaginationService, useValue: paginationService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
     })
     .compileComponents();
   });
 
   beforeEach(() => {
+    routeStub.snapshot.queryParams = { ...paramObject };
+    collectionService.findById.calls.reset();
+    collectionService.getAuthorizedCollection.calls.reset();
+    paginationService.getFindListOptions.calls.reset();
+    paginationService.clearPagination.calls.reset();
     fixture = TestBed.createComponent(LicenseContractPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -77,19 +146,40 @@ describe('LicenseContractPageComponent', () => {
   });
 
   it('should load collectionRD$', () => {
-    collectionService.findById(collection.uuid)
-      .pipe(getFirstCompletedRemoteData())
-      .subscribe(collectionRD$ => {
-        expect(component.collectionRD$.value).toEqual(collectionRD$);
-      });
+    expect(component.collectionRD$.value.payload).toEqual(collection);
   });
 
   it('should load licenseRD$', () => {
-    collection.license
-      .pipe(take(1))
-      .subscribe(licenseRD$ => {
-        expect(component.licenseRD$.value).toEqual(licenseRD$);
-      });
+    expect(component.licenseRD$.value.payload).toEqual(singleCollectionLicense);
+  });
+
+  it('should load authorized collections when collectionId is missing', () => {
+    routeStub.snapshot.queryParams = {};
+    collectionService.findById.calls.reset();
+    collectionService.getAuthorizedCollection.calls.reset();
+
+    const listFixture = TestBed.createComponent(LicenseContractPageComponent);
+    const listComponent = listFixture.componentInstance;
+    listFixture.detectChanges();
+
+    expect(collectionService.findById).not.toHaveBeenCalled();
+    expect(collectionService.getAuthorizedCollection).toHaveBeenCalled();
+
+    listComponent.collectionsRD$.subscribe((collectionsRD) => {
+      expect(collectionsRD.payload.page).toEqual(authorizedCollections);
+    });
+  });
+
+  it('should clear pagination state on destroy in list mode', () => {
+    routeStub.snapshot.queryParams = {};
+    paginationService.clearPagination.calls.reset();
+
+    const listFixture = TestBed.createComponent(LicenseContractPageComponent);
+    const listComponent = listFixture.componentInstance;
+    listFixture.detectChanges();
+    listComponent.ngOnDestroy();
+
+    expect(paginationService.clearPagination).toHaveBeenCalledWith(listComponent.paginationId);
   });
 
 });

--- a/src/app/license-contract-page/license-contract-page.component.ts
+++ b/src/app/license-contract-page/license-contract-page.component.ts
@@ -1,13 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import { RemoteData } from '../core/data/remote-data';
 import { Collection } from '../core/shared/collection.model';
 import { CollectionDataService } from '../core/data/collection-data.service';
 import { License } from '../core/shared/license.model';
 import { followLink } from '../shared/utils/follow-link-config.model';
 import { filter } from 'rxjs/operators';
-import { isNotUndefined } from '../shared/empty.util';
+import { isNotEmpty, isNotUndefined } from '../shared/empty.util';
+import { PaginatedList } from '../core/data/paginated-list.model';
+import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
+import { FindListOptions } from '../core/data/find-list-options.model';
+import { PaginationService } from '../core/pagination/pagination.service';
 
 /**
  * The component load and show distribution license based on the collection.
@@ -17,10 +22,13 @@ import { isNotUndefined } from '../shared/empty.util';
   templateUrl: './license-contract-page.component.html',
   styleUrls: ['./license-contract-page.component.scss']
 })
-export class LicenseContractPageComponent implements OnInit {
+export class LicenseContractPageComponent implements OnInit, OnDestroy {
+
+  readonly paginationId = 'contract-collections';
 
   constructor(private route: ActivatedRoute,
-              protected collectionDataService: CollectionDataService,) {
+              protected collectionDataService: CollectionDataService,
+              protected paginationService: PaginationService,) {
   }
 
   /**
@@ -38,18 +46,56 @@ export class LicenseContractPageComponent implements OnInit {
    */
   licenseRD$: BehaviorSubject<RemoteData<License>> = new BehaviorSubject<RemoteData<License>>(null);
 
+  /**
+   * Collection list RemoteData object loaded from the API.
+   */
+  collectionsRD$: Observable<RemoteData<PaginatedList<Collection>>>;
+
+  /**
+   * The current pagination configuration for the page used by the authorized collection request.
+   */
+  config: FindListOptions = Object.assign(new FindListOptions(), {
+    elementsPerPage: 10
+  });
+
+  /**
+   * The current pagination configuration for the page.
+   */
+  pageConfig: PaginationComponentOptions = Object.assign(new PaginationComponentOptions(), {
+    id: this.paginationId,
+    pageSize: 10
+  });
+
   ngOnInit(): void {
     this.collectionId = this.route.snapshot.queryParams.collectionId;
-    this.collectionDataService.findById(this.collectionId, false, true, followLink('license'))
-      .pipe(
-        filter((collectionData: RemoteData<Collection>) => isNotUndefined((collectionData.payload))))
-      .subscribe(res => {
-        // load collection
-        this.collectionRD$.next(res);
-        res.payload.license.subscribe(licenseRD$ => {
-          // load license of the collection
-          this.licenseRD$.next(licenseRD$);
+    if (isNotEmpty(this.collectionId)) {
+      this.collectionDataService.findById(this.collectionId, false, true, followLink('license'))
+        .pipe(
+          filter((collectionData: RemoteData<Collection>) => isNotUndefined(collectionData.payload)))
+        .subscribe((res) => {
+          this.collectionRD$.next(res);
+          res.payload.license.subscribe((licenseRD$) => {
+            this.licenseRD$.next(licenseRD$);
+          });
         });
-      });
+    } else {
+      this.loadAuthorizedCollections();
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.isListMode()) {
+      this.paginationService.clearPagination(this.paginationId);
+    }
+  }
+
+  isListMode(): boolean {
+    return !isNotEmpty(this.collectionId);
+  }
+
+  private loadAuthorizedCollections(): void {
+    this.collectionsRD$ = this.paginationService.getFindListOptions(this.paginationId, this.config).pipe(
+      switchMap((config: FindListOptions) => this.collectionDataService.getAuthorizedCollection('', config, true, true, followLink('license')))
+    );
   }
 }

--- a/src/app/license-contract-page/license-contract-page.component.ts
+++ b/src/app/license-contract-page/license-contract-page.component.ts
@@ -71,8 +71,8 @@ export class LicenseContractPageComponent implements OnInit, OnDestroy {
     if (isNotEmpty(this.collectionId)) {
       this.collectionDataService.findById(this.collectionId, false, true, followLink('license'))
         .pipe(
-          filter((collectionData: RemoteData<Collection>) => isNotEmpty(collectionData.payload)),
           tap((collectionData: RemoteData<Collection>) => this.collectionRD$.next(collectionData)),
+          filter((collectionData: RemoteData<Collection>) => isNotEmpty(collectionData.payload)),
           switchMap((collectionData: RemoteData<Collection>) => collectionData.payload.license ?? EMPTY),
           tap((licenseRD: RemoteData<License>) => this.licenseRD$.next(licenseRD)),
           takeUntil(this.destroy$)

--- a/src/app/license-contract-page/license-contract-page.component.ts
+++ b/src/app/license-contract-page/license-contract-page.component.ts
@@ -1,13 +1,12 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { filter, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { RemoteData } from '../core/data/remote-data';
 import { Collection } from '../core/shared/collection.model';
 import { CollectionDataService } from '../core/data/collection-data.service';
 import { License } from '../core/shared/license.model';
 import { followLink } from '../shared/utils/follow-link-config.model';
-import { filter } from 'rxjs/operators';
 import { isNotEmpty, isNotUndefined } from '../shared/empty.util';
 import { PaginatedList } from '../core/data/paginated-list.model';
 import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
@@ -25,6 +24,7 @@ import { PaginationService } from '../core/pagination/pagination.service';
 export class LicenseContractPageComponent implements OnInit, OnDestroy {
 
   readonly paginationId = 'contract-collections';
+  private readonly destroy$ = new Subject<void>();
 
   constructor(private route: ActivatedRoute,
               protected collectionDataService: CollectionDataService,
@@ -71,19 +71,21 @@ export class LicenseContractPageComponent implements OnInit, OnDestroy {
     if (isNotEmpty(this.collectionId)) {
       this.collectionDataService.findById(this.collectionId, false, true, followLink('license'))
         .pipe(
-          filter((collectionData: RemoteData<Collection>) => isNotUndefined(collectionData.payload)))
-        .subscribe((res) => {
-          this.collectionRD$.next(res);
-          res.payload.license.subscribe((licenseRD$) => {
-            this.licenseRD$.next(licenseRD$);
-          });
-        });
+          filter((collectionData: RemoteData<Collection>) => isNotUndefined(collectionData.payload)),
+          tap((collectionData: RemoteData<Collection>) => this.collectionRD$.next(collectionData)),
+          switchMap((collectionData: RemoteData<Collection>) => collectionData.payload.license),
+          tap((licenseRD: RemoteData<License>) => this.licenseRD$.next(licenseRD)),
+          takeUntil(this.destroy$)
+        )
+        .subscribe();
     } else {
       this.loadAuthorizedCollections();
     }
   }
 
   ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
     if (this.isListMode()) {
       this.paginationService.clearPagination(this.paginationId);
     }

--- a/src/app/license-contract-page/license-contract-page.component.ts
+++ b/src/app/license-contract-page/license-contract-page.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, EMPTY, Observable, Subject } from 'rxjs';
 import { filter, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { RemoteData } from '../core/data/remote-data';
 import { Collection } from '../core/shared/collection.model';
 import { CollectionDataService } from '../core/data/collection-data.service';
 import { License } from '../core/shared/license.model';
 import { followLink } from '../shared/utils/follow-link-config.model';
-import { isNotEmpty, isNotUndefined } from '../shared/empty.util';
+import { isNotEmpty } from '../shared/empty.util';
 import { PaginatedList } from '../core/data/paginated-list.model';
 import { PaginationComponentOptions } from '../shared/pagination/pagination-component-options.model';
 import { FindListOptions } from '../core/data/find-list-options.model';
@@ -71,9 +71,9 @@ export class LicenseContractPageComponent implements OnInit, OnDestroy {
     if (isNotEmpty(this.collectionId)) {
       this.collectionDataService.findById(this.collectionId, false, true, followLink('license'))
         .pipe(
-          filter((collectionData: RemoteData<Collection>) => isNotUndefined(collectionData.payload)),
+          filter((collectionData: RemoteData<Collection>) => isNotEmpty(collectionData.payload)),
           tap((collectionData: RemoteData<Collection>) => this.collectionRD$.next(collectionData)),
-          switchMap((collectionData: RemoteData<Collection>) => collectionData.payload.license),
+          switchMap((collectionData: RemoteData<Collection>) => collectionData.payload.license ?? EMPTY),
           tap((licenseRD: RemoteData<License>) => this.licenseRD$.next(licenseRD)),
           takeUntil(this.destroy$)
         )


### PR DESCRIPTION
This pull request enhances the `LicenseContractPageComponent`, it keeps the previous functionality when collectionId is supplied and switches to "list mode" otherwise. The list mode shows all the collections (and their licenses) to which the current user has submission rights.

 The most important changes are grouped by feature and testing improvements:

**Feature: Support for List Mode and Pagination**
* The component now supports displaying a paginated list of authorized collections when no `collectionId` is provided, including UI changes to render a paginated list, handle empty states, and display loading/errors. (`src/app/license-contract-page/license-contract-page.component.html`, `src/app/license-contract-page/license-contract-page.component.ts`) [[1]](diffhunk://#diff-bc5a524d2809ee59167da36263e29142f52dc8b072b0481c2b6e851567baf02cL2-R44) [[2]](diffhunk://#diff-d7846caa4f050de4a10e9a5215708fe09e7f181d5d98bcd9740f586e9fa0ccf6L1-R14) [[3]](diffhunk://#diff-d7846caa4f050de4a10e9a5215708fe09e7f181d5d98bcd9740f586e9fa0ccf6L20-R31) [[4]](diffhunk://#diff-d7846caa4f050de4a10e9a5215708fe09e7f181d5d98bcd9740f586e9fa0ccf6R49-R101)
* Introduces pagination configuration and uses the `PaginationService` to manage and clear pagination state when appropriate. (`src/app/license-contract-page/license-contract-page.component.ts`) [[1]](diffhunk://#diff-d7846caa4f050de4a10e9a5215708fe09e7f181d5d98bcd9740f586e9fa0ccf6L1-R14) [[2]](diffhunk://#diff-d7846caa4f050de4a10e9a5215708fe09e7f181d5d98bcd9740f586e9fa0ccf6L20-R31) [[3]](diffhunk://#diff-d7846caa4f050de4a10e9a5215708fe09e7f181d5d98bcd9740f586e9fa0ccf6R49-R101)

**Testing Improvements**
* Updates and expands the component spec to test both single collection and list modes, including the new pagination logic and destruction behavior. (`src/app/license-contract-page/license-contract-page.component.spec.ts`) [[1]](diffhunk://#diff-5747e5da73db9d55baf324c2e2a518578179f84b400c07c0ce6492ff04b9d90bR8-R108) [[2]](diffhunk://#diff-5747e5da73db9d55baf324c2e2a518578179f84b400c07c0ce6492ff04b9d90bL56-R139) [[3]](diffhunk://#diff-5747e5da73db9d55baf324c2e2a518578179f84b400c07c0ce6492ff04b9d90bL80-R183)
* Adds a mock directive for `ngVar` and stubs/mocks for pagination and collection services to enable comprehensive testing of new scenarios. (`src/app/license-contract-page/license-contract-page.component.spec.ts`) [[1]](diffhunk://#diff-5747e5da73db9d55baf324c2e2a518578179f84b400c07c0ce6492ff04b9d90bR8-R108) [[2]](diffhunk://#diff-5747e5da73db9d55baf324c2e2a518578179f84b400c07c0ce6492ff04b9d90bL56-R139)

These changes make the license contract page more flexible and robust, supporting both individual collection and authorized collections views with proper pagination and error handling.
