### PR TITLE
Fix broken contract link on static about page

### DIFF
--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -259,10 +259,10 @@ describe('StaticPageComponent', () => {
       expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/contract`);
     });
 
-    it('should strip the no_static_ prefix and preserve the UI namespace', async () => {
+    it('should navigate licenses links relative to the UI namespace', async () => {
       const { component } = await setupTest('<div>test</div>');
       const navigateTo = spyOn<any>(component, 'navigateTo');
-      const event = createLinkEvent('no_static_licenses');
+      const event = createLinkEvent('licenses');
 
       component.processLinks(event);
 

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -44,7 +44,7 @@ describe('StaticPageComponent', () => {
       ...environment,
       ui: {
         ...(environment as any).ui,
-        namespace: 'testNamespace'
+        nameSpace: '/testNamespace'
       },
       rest: {
         ...(environment as any).rest,
@@ -68,6 +68,23 @@ describe('StaticPageComponent', () => {
     const fixture = TestBed.createComponent(StaticPageComponent);
     const component = fixture.componentInstance;
     return { fixture, component, htmlContentService, responseService };
+  }
+
+  function createLinkEvent(href: string, useNestedTarget = false): Event {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', href);
+
+    let target: EventTarget = anchor;
+    if (useNestedTarget) {
+      const nestedElement = document.createElement('span');
+      anchor.appendChild(nestedElement);
+      target = nestedElement;
+    }
+
+    return {
+      target,
+      preventDefault: jasmine.createSpy('preventDefault')
+    } as unknown as Event;
   }
 
   it('should create', async () => {
@@ -227,6 +244,60 @@ describe('StaticPageComponent', () => {
       await component.ngOnInit();
 
       expect((component as any).changeDetector.detectChanges).toHaveBeenCalled();
+    });
+  });
+
+  describe('link handling', () => {
+    it('should navigate standard internal links relative to the UI namespace', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('contract');
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/contract`);
+    });
+
+    it('should strip the no_static_ prefix and preserve the UI namespace', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('no_static_licenses');
+
+      component.processLinks(event);
+
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/licenses`);
+    });
+
+    it('should keep dot-relative links under the static route', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('./cite');
+
+      component.processLinks(event);
+
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/static/cite`);
+    });
+
+    it('should preserve fragment links on the current static page', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      component.htmlFileName = 'test-file.html';
+      const event = createLinkEvent('#about-contracts');
+
+      component.processLinks(event);
+
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/static/test-file.html#about-contracts`);
+    });
+
+    it('should resolve clicks from nested elements inside anchors', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('contract', true);
+
+      component.processLinks(event);
+
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/contract`);
     });
   });
 });

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -248,56 +248,48 @@ describe('StaticPageComponent', () => {
   });
 
   describe('link handling', () => {
-    it('should navigate standard internal links relative to the UI namespace', async () => {
-      const { component } = await setupTest('<div>test</div>');
-      const navigateTo = spyOn<any>(component, 'navigateTo');
-      const event = createLinkEvent('contract');
-
-      component.processLinks(event);
-
-      expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
-      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/contract`);
-    });
-
-    it('should navigate licenses links relative to the UI namespace', async () => {
-      const { component } = await setupTest('<div>test</div>');
-      const navigateTo = spyOn<any>(component, 'navigateTo');
-      const event = createLinkEvent('licenses');
-
-      component.processLinks(event);
-
-      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/licenses`);
-    });
-
-    it('should keep dot-relative links under the static route', async () => {
+    it('should intercept and navigate dot-relative links under the static route', async () => {
       const { component } = await setupTest('<div>test</div>');
       const navigateTo = spyOn<any>(component, 'navigateTo');
       const event = createLinkEvent('./cite');
 
       component.processLinks(event);
 
+      expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
       expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/static/cite`);
     });
 
-    it('should preserve fragment links on the current static page', async () => {
+    it('should resolve nested relative-link clicks inside anchors', async () => {
       const { component } = await setupTest('<div>test</div>');
       const navigateTo = spyOn<any>(component, 'navigateTo');
-      component.htmlFileName = 'test-file.html';
+      const event = createLinkEvent('../discover?query=test', true);
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/discover?query=test`);
+    });
+
+    it('should not intercept explicit app-route links', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('contract');
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).not.toHaveBeenCalled();
+      expect(navigateTo).not.toHaveBeenCalled();
+    });
+
+    it('should not intercept fragment links', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
       const event = createLinkEvent('#about-contracts');
 
       component.processLinks(event);
 
-      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/static/test-file.html#about-contracts`);
-    });
-
-    it('should resolve clicks from nested elements inside anchors', async () => {
-      const { component } = await setupTest('<div>test</div>');
-      const navigateTo = spyOn<any>(component, 'navigateTo');
-      const event = createLinkEvent('contract', true);
-
-      component.processLinks(event);
-
-      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/contract`);
+      expect((event.preventDefault as jasmine.Spy)).not.toHaveBeenCalled();
+      expect(navigateTo).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -17,7 +17,6 @@ import { ServerResponseService } from '../core/services/server-response.service'
   styleUrls: ['./static-page.component.scss']
 })
 export class StaticPageComponent implements OnInit {
-  static readonly no_static: string = 'no_static_';
   htmlContent: BehaviorSubject<string> = new BehaviorSubject<string>('');
   htmlFileName: string;
   contentState: 'loading' | 'found' | 'not-found' = 'loading';
@@ -139,9 +138,6 @@ export class StaticPageComponent implements OnInit {
   }
 
   private redirectToInternalLink(href: string, namespacePrefix: string): void {
-    if (href.startsWith(StaticPageComponent.no_static)) {
-      href = href.replace(StaticPageComponent.no_static, '');
-    }
     const absoluteUrl = new URL(href, this.composeAppBaseUrl(namespacePrefix));
     this.navigateTo(absoluteUrl.href);
   }

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -75,23 +75,14 @@ export class StaticPageComponent implements OnInit {
     }
 
     const href = anchorElement.getAttribute('href');
-    if (!href) {
+    if (!href || !this.isRelativeLink(href)) {
       return;
     }
 
     event.preventDefault();
     const namespacePrefix = this.getNamespacePrefix();
     const staticPageBaseUrl = this.composeStaticPageBaseUrl(namespacePrefix);
-
-    if (this.isFragmentLink(href)) {
-      this.redirectToFragment(staticPageBaseUrl, href);
-    } else if (this.isRelativeLink(href)) {
-      this.redirectToRelativeLink(staticPageBaseUrl, href);
-    } else if (this.isExternalLink(href)) {
-      this.redirectToExternalLink(href);
-    } else {
-      this.redirectToInternalLink(href, namespacePrefix);
-    }
+    this.redirectToRelativeLink(staticPageBaseUrl, href);
   }
 
   private getNamespacePrefix(): string {
@@ -109,18 +100,6 @@ export class StaticPageComponent implements OnInit {
     return this.composeUrl(`${namespacePrefix}/${STATIC_PAGE_PATH}/`);
   }
 
-  private composeAppBaseUrl(namespacePrefix: string): string {
-    return this.composeUrl(`${namespacePrefix}/`);
-  }
-
-  private isFragmentLink(href: string | null): boolean {
-    return href?.startsWith('#') ?? false;
-  }
-
-  private redirectToFragment(redirectUrl: string, href: string | null): void {
-    this.navigateTo(`${redirectUrl}${this.htmlFileName}${href}`);
-  }
-
   private isRelativeLink(href: string | null): boolean {
     return href?.startsWith('.') ?? false;
   }
@@ -129,25 +108,8 @@ export class StaticPageComponent implements OnInit {
     this.navigateTo(new URL(href, redirectUrl).href);
   }
 
-  private isExternalLink(href: string | null): boolean {
-    return (href?.startsWith('http') || href?.startsWith('www')) ?? false;
-  }
-
-  private redirectToExternalLink(href: string | null): void {
-    this.replaceLocation(href);
-  }
-
-  private redirectToInternalLink(href: string, namespacePrefix: string): void {
-    const absoluteUrl = new URL(href, this.composeAppBaseUrl(namespacePrefix));
-    this.navigateTo(absoluteUrl.href);
-  }
-
   private navigateTo(url: string): void {
     window.location.href = url;
-  }
-
-  private replaceLocation(url: string): void {
-    window.location.replace(url);
   }
 
   /**

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -69,38 +69,49 @@ export class StaticPageComponent implements OnInit {
    * @param event
    */
   processLinks(event: Event): void {
-    const targetElement = event.target as HTMLElement;
+    const targetElement = event.target as HTMLElement | null;
+    const anchorElement = targetElement?.closest?.('a');
+    if (!anchorElement) {
+      return;
+    }
 
-    if (targetElement.nodeName !== 'A') {
+    const href = anchorElement.getAttribute('href');
+    if (!href) {
       return;
     }
 
     event.preventDefault();
-
-    const href = targetElement.getAttribute('href');
-    const { nameSpace } = this.appConfig.ui;
-    const namespacePrefix = nameSpace === '/' ? '' : nameSpace;
-
-    const redirectUrl = this.composeRedirectUrl(href, namespacePrefix);
+    const namespacePrefix = this.getNamespacePrefix();
+    const staticPageBaseUrl = this.composeStaticPageBaseUrl(namespacePrefix);
 
     if (this.isFragmentLink(href)) {
-      this.redirectToFragment(redirectUrl, href);
+      this.redirectToFragment(staticPageBaseUrl, href);
     } else if (this.isRelativeLink(href)) {
-      this.redirectToRelativeLink(redirectUrl, href);
+      this.redirectToRelativeLink(staticPageBaseUrl, href);
     } else if (this.isExternalLink(href)) {
       this.redirectToExternalLink(href);
     } else {
-      this.redirectToAbsoluteLink(redirectUrl, href, namespacePrefix);
+      this.redirectToInternalLink(href, namespacePrefix);
     }
   }
 
-  private composeRedirectUrl(href: string | null, namespacePrefix: string): string {
-    const staticPagePath = STATIC_PAGE_PATH;
+  private getNamespacePrefix(): string {
+    const nameSpace = this.appConfig?.ui?.nameSpace ?? '/';
+    return nameSpace === '/' ? '' : nameSpace.replace(/\/$/, '');
+  }
+
+  private composeUrl(pathname: string): string {
     const baseUrl = new URL(window.location.origin);
-    baseUrl.pathname = href.startsWith(StaticPageComponent.no_static)
-            ? `${namespacePrefix}/`
-            : `${namespacePrefix}/${staticPagePath}/`;
+    baseUrl.pathname = pathname;
     return baseUrl.href;
+  }
+
+  private composeStaticPageBaseUrl(namespacePrefix: string): string {
+    return this.composeUrl(`${namespacePrefix}/${STATIC_PAGE_PATH}/`);
+  }
+
+  private composeAppBaseUrl(namespacePrefix: string): string {
+    return this.composeUrl(`${namespacePrefix}/`);
   }
 
   private isFragmentLink(href: string | null): boolean {
@@ -108,7 +119,7 @@ export class StaticPageComponent implements OnInit {
   }
 
   private redirectToFragment(redirectUrl: string, href: string | null): void {
-    window.location.href = `${redirectUrl}${this.htmlFileName}${href}`;
+    this.navigateTo(`${redirectUrl}${this.htmlFileName}${href}`);
   }
 
   private isRelativeLink(href: string | null): boolean {
@@ -116,7 +127,7 @@ export class StaticPageComponent implements OnInit {
   }
 
   private redirectToRelativeLink(redirectUrl: string, href: string | null): void {
-    window.location.href = new URL(href, redirectUrl).href;
+    this.navigateTo(new URL(href, redirectUrl).href);
   }
 
   private isExternalLink(href: string | null): boolean {
@@ -124,15 +135,23 @@ export class StaticPageComponent implements OnInit {
   }
 
   private redirectToExternalLink(href: string | null): void {
-    window.location.replace(href);
+    this.replaceLocation(href);
   }
 
-  private redirectToAbsoluteLink(redirectUrl: string, href: string | null, namespacePrefix: string): void {
+  private redirectToInternalLink(href: string, namespacePrefix: string): void {
     if (href.startsWith(StaticPageComponent.no_static)) {
       href = href.replace(StaticPageComponent.no_static, '');
     }
-    const absoluteUrl = new URL(href, redirectUrl.replace(namespacePrefix, ''));
-    window.location.href = absoluteUrl.href;
+    const absoluteUrl = new URL(href, this.composeAppBaseUrl(namespacePrefix));
+    this.navigateTo(absoluteUrl.href);
+  }
+
+  private navigateTo(url: string): void {
+    window.location.href = url;
+  }
+
+  private replaceLocation(url: string): void {
+    window.location.replace(url);
   }
 
   /**

--- a/src/static-files/about.html
+++ b/src/static-files/about.html
@@ -5,16 +5,16 @@
 
     <hr />
 	<ul id="faqs-list">
-		<li><a href="#mission-statement">Mission Statement</a></li>
-		<li><a href="#terms-of-service">Terms of Service</a></li>
-		<li><a href="#about-repository">About Repository</a></li>
-		<li><a href="#about-ufal">About UFAL</a></li>
-		<li><a href="#about-contracts">License Agreement and Contracts</a></li>
-		<li><a href="#about-ipr">Intellectual Property Rights</a></li>
-		<li><a href="#privacy-policy">Privacy Policy</a></li>
-		<li><a href="#metadata-policy">Metadata Policy</a></li>
-		<li><a href="#preservation-policy">Preservation Policy</a></li>
-		<li><a href="./cite">Citing Data Policy</a></li>
+		<li><a href="static/about#mission-statement">Mission Statement</a></li>
+		<li><a href="static/about#terms-of-service">Terms of Service</a></li>
+		<li><a href="static/about#about-repository">About Repository</a></li>
+		<li><a href="static/about#about-ufal">About UFAL</a></li>
+		<li><a href="static/about#about-contracts">License Agreement and Contracts</a></li>
+		<li><a href="static/about#about-ipr">Intellectual Property Rights</a></li>
+		<li><a href="static/about#privacy-policy">Privacy Policy</a></li>
+		<li><a href="static/about#metadata-policy">Metadata Policy</a></li>
+		<li><a href="static/about#preservation-policy">Preservation Policy</a></li>
+		<li><a href="static/cite">Citing Data Policy</a></li>
 	</ul>
     <hr />
 	<div>
@@ -33,12 +33,12 @@
 	<div>
 		<h3 id="terms-of-service">Terms of Service</h3>
 		<p>
-        To achieve our mission statement,we set out some ground rules through the <a href="./terms-of-service">Terms of Service</a>. By accessing or using any kind of data or services provided by the Repository, you agree to abide by the Terms contained in the above mentioned document.
+		To achieve our mission statement,we set out some ground rules through the <a href="static/terms-of-service">Terms of Service</a>. By accessing or using any kind of data or services provided by the Repository, you agree to abide by the Terms contained in the above mentioned document.
         </p>
         <p>
         Data in LINDAT/CLARIAH-CZ repository are made available under the licence attached to the resources. In case there is no licence, data is made freely available for access, printing and download for the purposes of non-commercial research or private study.
 
-        Users <strong>must</strong> acknowledge in any publication, the Deposited Work using a persistent identifier (see <a href="./cite">Citing Data</a>), its original author(s)/creator(s), and any publisher where applicable. Full items must not be harvested by robots except transiently for full-text indexing or citation analysis. Full items must not be sold commercially unless explicitly granted by the attached licence without formal permission of the copyright holders.
+		Users <strong>must</strong> acknowledge in any publication, the Deposited Work using a persistent identifier (see <a href="static/cite">Citing Data</a>), its original author(s)/creator(s), and any publisher where applicable. Full items must not be harvested by robots except transiently for full-text indexing or citation analysis. Full items must not be sold commercially unless explicitly granted by the attached licence without formal permission of the copyright holders.
         </p>
 	</div>
 
@@ -73,7 +73,7 @@
 	<div>
 		<h3 id="about-ipr">Intellectual Property Rights</h3>
 		<p>
-As mentioned in the section <a href="#about-contracts">License Agreement and Contracts</a>, we require the depositor of data or tools to sign a Distribution License Agreement, which specifies that they have the right to submit the data and gives us (the repository centre) right to distribute the data on their behalf. This means that depositors are solely responsible for taking care of IPR issues before publishing data or tools by submitting them to us.
+As mentioned in the section <a href="static/about#about-contracts">License Agreement and Contracts</a>, we require the depositor of data or tools to sign a Distribution License Agreement, which specifies that they have the right to submit the data and gives us (the repository centre) right to distribute the data on their behalf. This means that depositors are solely responsible for taking care of IPR issues before publishing data or tools by submitting them to us.
 <br/>
 Should anyone have a suspicion that any of the datasets or tools in our repository violate Intellectual Property Rights, they should contact us immediately at our help desk.
 </p>
@@ -90,7 +90,7 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
     <div>
 		<h3 id="metadata-policy">Metadata Policy</h3>
 		<p>
-       Deposited content must be accompanied by <a href="metadata">sufficient metadata</a> describing its content, provenance and formats in order to support its preservation and dissemination. Metadata are freely accessible and are distributed in the public domain (under <a href="http://creativecommons.org/about/cc0">CC0</a>). However, we reserve the right to be informed about commercial usage of metadata from LINDAT/CLARIAH-CZ repository including a description of your use case at <a class="helpdesk-tolink" href="#">Help Desk</a>.
+	   Deposited content must be accompanied by <a href="static/metadata">sufficient metadata</a> describing its content, provenance and formats in order to support its preservation and dissemination. Metadata are freely accessible and are distributed in the public domain (under <a href="http://creativecommons.org/about/cc0">CC0</a>). However, we reserve the right to be informed about commercial usage of metadata from LINDAT/CLARIAH-CZ repository including a description of your use case at <a class="helpdesk-tolink" href="#">Help Desk</a>.
         </p>
 	</div>
 	<br/>
@@ -100,7 +100,7 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
 		<p>
 			LINDAT/CLARIAH-CZ is committed to the long-term care of items deposited in the repository, to preserve the
 			research and to help in keeping research replicable and strives to adopt the
-			current best practice in digital preservation. See the <a href="#mission-statement">Mission Statement</a>.
+			current best practice in digital preservation. See the <a href="static/about#mission-statement">Mission Statement</a>.
 			We follow best practice guidelines, standards and regulations set forth by CLARIN, OAIS and/or Charles
 			University.
 		</p>
@@ -110,12 +110,12 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
 		</p>
 		<p>
 			To fulfill the commitments, the repository ensures that datasets are ingested and distributed in
-			accordance with their license (see <a href="#about-contracts">agreements and contracts</a>). Sometimes
+			accordance with their license (see <a href="static/about#about-contracts">agreements and contracts</a>). Sometimes
 			(for licenses that do not permit public access) this means only authorized users can access the dataset.
 		</p>
 		<p>
-			The submission workflow as described in <a href="deposit">deposit</a> and the work of our editors ensures
-			discoverability (by requiring accurate <a href="#metadata-policy">metadata</a>) via our search engine,
+			The submission workflow as described in <a href="static/deposit">deposit</a> and the work of our editors ensures
+			discoverability (by requiring accurate <a href="static/about#metadata-policy">metadata</a>) via our search engine,
 			externally through OAI-PMH  and in page metadata for certain web crawlers. Metadata are freely accessible.
 		</p>
 		<p>
@@ -126,7 +126,7 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
 		</p>
         <p>
 			We view data and tools as primary research outputs, each submission receives a Persistent IDentifier for reference and
-			the users are <a href="cite">guided to</a> use them. Changes in a dataset after it has been published are
+			the users are <a href="static/cite">guided to</a> use them. Changes in a dataset after it has been published are
 			not permitted, new submission is required instead. The old and new submissions are linked through their
 			metadata (see <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">new version
 			guide</a> 	for more details).

--- a/src/static-files/about.html
+++ b/src/static-files/about.html
@@ -64,7 +64,7 @@
 		<h3 id="about-contracts">License Agreement and Contracts</h3>
 		<p>At the moment, UFAL distinguishes three types of contracts.</p>
 		<ul>
-			<li>For every deposit, we enter into a standard contract with the submitter, the so-called <a id="distribution-link" href="contract">"Distribution License Agreement"</a>, in which we describe our rights and duties and the submitter acknowledges that they have the right to submit the data and gives us (the repository centre) right to distribute the data on their behalf.</li>
+			<li>For every deposit, we enter into a standard contract with the submitter, the so-called <a id="distribution-link" href="contract">"Distribution License Agreement"</a> , in which we describe our rights and duties and the submitter acknowledges that they have the right to submit the data and gives us (the repository centre) right to distribute the data on their behalf. Note that the linked page is dynamic, when you get there from the submission workflow it shows you the contract only for the current collection, otherwise it shows you the contracts to all the collections you can submit into.</li>
 			<li>Everyone who downloads data is bound by the licence assigned to the item - in order to download protected data, one has to be authenticated and needs to electronically sign the licence. A list of available licenses in our repository can be found <a href="licenses" id="available-licenses">here.</a></li>
 			<li>For submitters, there is a possibility for setting custom licences to items during the submission workflow.</li>
 		</ul>
@@ -82,7 +82,7 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
 
 	<div>
 		<h3 id="privacy-policy">Privacy Policy</h3>
-		<p>Read our <a href="./privacypolicy.html">Privacy Policy</a> in order to learn how we manage personal data collected by the LINDAT/CLARIAH-CZ repository and services.
+		<p>Read our <a href="https://lindat.mff.cuni.cz/policy">Privacy Policy</a> in order to learn how we manage personal data collected by the LINDAT/CLARIAH-CZ repository and services.
         </p>
 	</div>
 	<br/>
@@ -106,7 +106,7 @@ Should anyone have a suspicion that any of the datasets or tools in our reposito
 		</p>
 		<p>
 			In order to stay a reliable and trustworthy repository, we undergo periodical assessments by CLARIN ERIC and
-			<a href="https://www.coretrustseal.org/wp-content/uploads/2019/08/LINDAT-CLARIN.pdf">CTS</a> (formerly DSA).
+			<a href="https://hdl.handle.net/11234/6-CTS">CTS</a> (formerly DSA).
 		</p>
 		<p>
 			To fulfill the commitments, the repository ensures that datasets are ingested and distributed in

--- a/src/static-files/about.html
+++ b/src/static-files/about.html
@@ -65,7 +65,7 @@
 		<p>At the moment, UFAL distinguishes three types of contracts.</p>
 		<ul>
 			<li>For every deposit, we enter into a standard contract with the submitter, the so-called <a id="distribution-link" href="contract">"Distribution License Agreement"</a>, in which we describe our rights and duties and the submitter acknowledges that they have the right to submit the data and gives us (the repository centre) right to distribute the data on their behalf.</li>
-			<li>Everyone who downloads data is bound by the licence assigned to the item - in order to download protected data, one has to be authenticated and needs to electronically sign the licence. A list of available licenses in our repository can be found <a href="no_static_licenses" id="available-licenses">here.</a></li>
+			<li>Everyone who downloads data is bound by the licence assigned to the item - in order to download protected data, one has to be authenticated and needs to electronically sign the licence. A list of available licenses in our repository can be found <a href="licenses" id="available-licenses">here.</a></li>
 			<li>For submitters, there is a possibility for setting custom licences to items during the submission workflow.</li>
 		</ul>
 	</div>

--- a/src/static-files/cs/about.html
+++ b/src/static-files/cs/about.html
@@ -5,16 +5,16 @@
 
     <hr />
 	<ul id="faqs-list">
-		<li><a href="#mission-statement">Naše poslání</a></li>
-		<li><a href="#terms-of-service">Pravidla použití služeb</a></li>
-		<li><a href="#about-repository">O repozitáři</a></li>
-		<li><a href="#about-ufal">O ÚFALu</a></li>
-		<li><a href="#about-contracts">Licenční ujednání a smlouvy</a></li>
-		<li><a href="#about-ipr">Práva k duševnímu vlastnictví</a></li>
-		<li><a href="#privacy-policy">Pravidla uchovávání osobních údajů</a></li>
-		<li><a href="#metadata-policy">Pravidla pro metadata</a></li>
-		<li><a href="#preservation-policy">Pravidla pro uchovávání dat</a></li>
-		<li><a href="./cite">Pravidla pro citace</a></li>
+		<li><a href="static/about#mission-statement">Naše poslání</a></li>
+		<li><a href="static/about#terms-of-service">Pravidla použití služeb</a></li>
+		<li><a href="static/about#about-repository">O repozitáři</a></li>
+		<li><a href="static/about#about-ufal">O ÚFALu</a></li>
+		<li><a href="static/about#about-contracts">Licenční ujednání a smlouvy</a></li>
+		<li><a href="static/about#about-ipr">Práva k duševnímu vlastnictví</a></li>
+		<li><a href="static/about#privacy-policy">Pravidla uchovávání osobních údajů</a></li>
+		<li><a href="static/about#metadata-policy">Pravidla pro metadata</a></li>
+		<li><a href="static/about#preservation-policy">Pravidla pro uchovávání dat</a></li>
+		<li><a href="static/cite">Pravidla pro citace</a></li>
 	</ul>
     <hr />
 	<div>
@@ -31,12 +31,12 @@
 	<div>
 		<h3 id="terms-of-service">Pravidla použití služeb</h3>
 		<p>
-        Pro dosažení našeho poslání jsme stanovili některá základní nařízení prostřednictvím <a href="./terms-of-service">Pravidel pro použití služeb</a>. Používáním repozitáře LINDAT/CLARIAH-CZ nebo použitím jakýchkoliv dat nebo služeb poskytovaných prostřednictvím LINDAT/CLARIAH-CZ souhlasíte s tím, že budete dodržovat podmínky obsažené ve výše uvedeném dokumentu.
+		Pro dosažení našeho poslání jsme stanovili některá základní nařízení prostřednictvím <a href="static/terms-of-service">Pravidel pro použití služeb</a>. Používáním repozitáře LINDAT/CLARIAH-CZ nebo použitím jakýchkoliv dat nebo služeb poskytovaných prostřednictvím LINDAT/CLARIAH-CZ souhlasíte s tím, že budete dodržovat podmínky obsažené ve výše uvedeném dokumentu.
         </p>
         <p>
         Data v repozitáři LINDAT/CLARIAH-CZ jsou k dispozici na základě licence  uvedené u jednotlivých zdrojů (položek). Pokud zde licence uvedena není, data jsou volně k dispozici, a to jak pro přístup a tisk, tak také ke stažení pro účely nekomerčního výzkumu nebo pro soukromé studium.
 
-        Uživatel <strong>musí</strong> v každé své publikaci pomocí stálého ("perzistentního") identifikátoru (PID, viz <a href="./cite">Pravidla pro citace</a>) uvést, jaká data použil, dále musí uvést jejich  původního autora a v případě potřeby také jejich vydavatele. Žádné položky nesmí být využívány roboty, s výjimkou dočasného zpracování pro fulltextové indexování nebo analýzy citací. Žádné položky nesmí být bez formálního souhlasu majitele autorských práv komerčně prodávány, jedině pokud je to výslovně dovoleno na základě licence uvedené u dané položky v repozitáři.
+		Uživatel <strong>musí</strong> v každé své publikaci pomocí stálého ("perzistentního") identifikátoru (PID, viz <a href="static/cite">Pravidla pro citace</a>) uvést, jaká data použil, dále musí uvést jejich  původního autora a v případě potřeby také jejich vydavatele. Žádné položky nesmí být využívány roboty, s výjimkou dočasného zpracování pro fulltextové indexování nebo analýzy citací. Žádné položky nesmí být bez formálního souhlasu majitele autorských práv komerčně prodávány, jedině pokud je to výslovně dovoleno na základě licence uvedené u dané položky v repozitáři.
         </p>
 	</div>
 
@@ -72,7 +72,7 @@
 	<div>
 		<h3 id="about-ipr">Práva k duševnímu vlastnictví</h3>
 		<p>
-Jak již bylo zmíněno v oddíle <a href="#about-contracts">Licenční ujednání a smlouvy</a>, požadujeme, aby vkladatel dat nebo nástrojů podepsal Licenční ujednání a smlouvu, v níž specifikujeme, že vkladatel má právo vložit data a dává nám (repozitáři) právo tato data jeho jménem distribuovat. To znamená, že vkladatelé vložením dat k nám do repozitáře nesou sami zodpovědnost za práva k duševnímu vlastnictví (IPR) ještě předtím, než v repozitáři jimi vložená data nebo nástroje dáme veřejně k dispozici (za jimi nastavených licenčních podmínek).
+Jak již bylo zmíněno v oddíle <a href="static/about#about-contracts">Licenční ujednání a smlouvy</a>, požadujeme, aby vkladatel dat nebo nástrojů podepsal Licenční ujednání a smlouvu, v níž specifikujeme, že vkladatel má právo vložit data a dává nám (repozitáři) právo tato data jeho jménem distribuovat. To znamená, že vkladatelé vložením dat k nám do repozitáře nesou sami zodpovědnost za práva k duševnímu vlastnictví (IPR) ještě předtím, než v repozitáři jimi vložená data nebo nástroje dáme veřejně k dispozici (za jimi nastavených licenčních podmínek).
 <br/>
 Pokud by někdo měl podezření, že některý z datových souborů nebo některé nástroje v našem repozitáři porušují práva k duševnímu vlastnictví, měl by nás okamžitě kontaktovat na <a class="helpdesk-tolink" href="#">Lince podpory</a>.
 </p>
@@ -89,7 +89,7 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
     <div>
 		<h3 id="metadata-policy">Pravidla pro metadata</h3>
 		<p>
-       Aby byl ve vložených položkách dat a nástrojů "pořádek" a bylo je možné snadno najít, čímž chceme podpořit jejich distribuci, musí být doprovázeny <a href="metadata">dostatečným množstvím metadat</a> popisujících obsah daných položek, jejich původ a formáty. Metadata jsou vždy volně přístupná a jsou  distribuována ve veřejné doméně (jako <a href="http://creativecommons.org/about/cc0">CC0</a>). Vyhrazujeme si však právo být informováni o komerčním využití metadat uložených v LINDAT/CLARIAH-CZ repozitáři, včetně popisu vašeho použití, a to na  <a class="helpdesk-tolink" href="#">Lince podpory</a>.
+	   Aby byl ve vložených položkách dat a nástrojů "pořádek" a bylo je možné snadno najít, čímž chceme podpořit jejich distribuci, musí být doprovázeny <a href="static/metadata">dostatečným množstvím metadat</a> popisujících obsah daných položek, jejich původ a formáty. Metadata jsou vždy volně přístupná a jsou  distribuována ve veřejné doméně (jako <a href="http://creativecommons.org/about/cc0">CC0</a>). Vyhrazujeme si však právo být informováni o komerčním využití metadat uložených v LINDAT/CLARIAH-CZ repozitáři, včetně popisu vašeho použití, a to na  <a class="helpdesk-tolink" href="#">Lince podpory</a>.
         </p>
 	</div>
 	<br/>
@@ -99,7 +99,7 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
 		<p>
         LINDAT/CLARIAH-CZ se zavázal k dlouhodobé péči o data a nástroje uložené v repozitáři a snaží se používat
 			nejlepší stávající osvědčené postupy v oblasti uchovávání digitálních záznamů, jak je stanovuje CLARIN,
-			OAIS a/nebo Univerzita Karlova. Viz	<a href="#mission-statement">Naše poslání</a>.
+			OAIS a/nebo Univerzita Karlova. Viz	<a href="static/about#mission-statement">Naše poslání</a>.
 		</p>
         <p>
 		Abychom zůstali spolehlivým a důvěryhodným úložištěm, podstupujeme pravidelná hodnocení ze strany CLARIN ERIC a
@@ -107,14 +107,14 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
 		</p>
 		<p>
 			Abychom mohli plnit naše závazky, repozitář zajišťuje, že přijatá data mají licenci a pod touto licencí
-			je dále poskytuje (viz <a href="#about-contracts">Licenční ujednání a smlouvy</a>). Někdy
+			je dále poskytuje (viz <a href="static/about#about-contracts">Licenční ujednání a smlouvy</a>). Někdy
 			(u licencí, které nepovolují volný přístup) to znamená, že k datům mají přístup pouze oprávnění
 			uživatelé.
 		</p>
         <p>
-			Proces nahrání dat popsaný v <a href="deposit">Jak ukládat vaše data</a> a práce našich editorů
+			Proces nahrání dat popsaný v <a href="static/deposit">Jak ukládat vaše data</a> a práce našich editorů
 			zajišťuje, že data budou k nalezení prostřednictvím našeho vyhledávače,
-			externě přes OAI-PMH a v různých dalších vyhledávačích. Proto vyžadujeme detailní  <a href="#metadata-policy">metadata</a>.
+			externě přes OAI-PMH a v různých dalších vyhledávačích. Proto vyžadujeme detailní  <a href="static/about#metadata-policy">metadata</a>.
 			Metadata jsou volně přístupná.
 		</p>
         <p>
@@ -124,7 +124,7 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
 		</p>
         <p>
 			Data i nástroje vnímáme jako hlavní výstupy výzkumu. Ke každému záznamu v repozitáři je přidělen
-			perzistentní identifikátor, který slouží jako trvalý odkaz. Uživatelé jsou <a href="cite">vedeni k
+			perzistentní identifikátor, který slouží jako trvalý odkaz. Uživatelé jsou <a href="static/cite">vedeni k
 			jejich používaní</a>.
 			Jednou zveřejněná data není možné měnit, vždy je potřeba vytvořit nový záznam. Oba záznamy (starý a nový)
 			jsou provázány odkazy (PID) v metadatech (viz <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">nová verze</a>).

--- a/src/static-files/cs/about.html
+++ b/src/static-files/cs/about.html
@@ -64,7 +64,7 @@
 		<p>V současné době se rozlišují tři typy smluv.</p>
 		<ul>
 			<li>Při každém vložení dat vstupujeme s tím, kdo data vkládá ("vkladatelem") do standardního smluvního vztahu - jde o tzv. <a id="distribution-link" href="contract">"Licenční ujednání"</a>, ve kterém popisujeme naše práva a povinnosti a vkladatel stvrzuje, že má právo svá data vložit. Zároveň nám dává právo tato data jeho jménem distribuovat prostřednictvím repozitáře LINDAT/CLARIAH-CZ.</li>
-			<li>Každý, kdo si data stáhne, je vázán licencí, která je k nim přiřazena. Pro stažení chráněných dat musí být uživatel identifikován jedním z ověřených způsobů a musí licenci elektronicky podepsat. Seznam všech licencí používaných v našem repozitáři lze nalézt <a href="no_static_licenses" id="available-licenses">zde.</a></li>
+			<li>Každý, kdo si data stáhne, je vázán licencí, která je k nim přiřazena. Pro stažení chráněných dat musí být uživatel identifikován jedním z ověřených způsobů a musí licenci elektronicky podepsat. Seznam všech licencí používaných v našem repozitáři lze nalézt <a href="licenses" id="available-licenses">zde.</a></li>
 			<li>Vkladatel má rovněž možnost zavést a následně nastavit pro vkládanou položku dat vlastní licenci, která bude po schválení administrátorem přidána do seznamu použitých licencí.</li>
     </ul>
 	</div>

--- a/src/static-files/cs/about.html
+++ b/src/static-files/cs/about.html
@@ -63,7 +63,7 @@
 		<h3 id="about-contracts">Licenční ujednání a smlouvy</h3>
 		<p>V současné době se rozlišují tři typy smluv.</p>
 		<ul>
-			<li>Při každém vložení dat vstupujeme s tím, kdo data vkládá ("vkladatelem") do standardního smluvního vztahu - jde o tzv. <a id="distribution-link" href="contract">"Licenční ujednání"</a>, ve kterém popisujeme naše práva a povinnosti a vkladatel stvrzuje, že má právo svá data vložit. Zároveň nám dává právo tato data jeho jménem distribuovat prostřednictvím repozitáře LINDAT/CLARIAH-CZ.</li>
+			<li>Při každém vložení dat vstupujeme s tím, kdo data vkládá ("vkladatelem") do standardního smluvního vztahu - jde o tzv. <a id="distribution-link" href="contract">"Licenční ujednání"</a>, ve kterém popisujeme naše práva a povinnosti a vkladatel stvrzuje, že má právo svá data vložit. Zároveň nám dává právo tato data jeho jménem distribuovat prostřednictvím repozitáře LINDAT/CLARIAH-CZ. Upozornění: odkázaná stránka je dynamická, pokud na ni přejdete během nahrávání záznamu, ukáže se vám ujednání jen pro danou kolekci. Jinak zobrazuje ujednání pro všechny kolekce, do kterých máte právo zápisu.</li>
 			<li>Každý, kdo si data stáhne, je vázán licencí, která je k nim přiřazena. Pro stažení chráněných dat musí být uživatel identifikován jedním z ověřených způsobů a musí licenci elektronicky podepsat. Seznam všech licencí používaných v našem repozitáři lze nalézt <a href="licenses" id="available-licenses">zde.</a></li>
 			<li>Vkladatel má rovněž možnost zavést a následně nastavit pro vkládanou položku dat vlastní licenci, která bude po schválení administrátorem přidána do seznamu použitých licencí.</li>
     </ul>
@@ -81,7 +81,7 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
 
 	<div>
 		<h3 id="privacy-policy">Pravidla uchovávání osobních údajů</h3>
-		<p>Přečtěte si prosím naše <a href="./privacypolicy.html">Pravidla uchovávání osobních údajů</a>, kde popisujeme, jak chráníme nutné osobní údaje shromážděné v LINDAT/CLARIAH-CZ repozitáři.
+		<p>Přečtěte si prosím naše <a href="https://lindat.mff.cuni.cz/policy">Pravidla uchovávání osobních údajů</a>, kde popisujeme, jak chráníme nutné osobní údaje shromážděné v LINDAT/CLARIAH-CZ repozitáři.
         </p>
 	</div>
 	<br/>
@@ -103,7 +103,7 @@ Pokud by někdo měl podezření, že některý z datových souborů nebo někte
 		</p>
         <p>
 		Abychom zůstali spolehlivým a důvěryhodným úložištěm, podstupujeme pravidelná hodnocení ze strany CLARIN ERIC a
-		<a href="https://www.coretrustseal.org/wp-content/uploads/2019/08/LINDAT-CLARIN.pdf">CTS</a> (dříve DSA).
+		<a href="https://hdl.handle.net/11234/6-CTS">CTS</a> (dříve DSA).
 		</p>
 		<p>
 			Abychom mohli plnit naše závazky, repozitář zajišťuje, že přijatá data mají licenci a pod touto licencí

--- a/src/static-files/cs/deposit.html
+++ b/src/static-files/cs/deposit.html
@@ -88,7 +88,7 @@
         <div id="step6" style="margin-bottom: 20px;">
                 <h3>Krok 6: Výběr licence</h3>
                 <p style="margin-top: 10px; margin-bottom: 10px;">Pokud nahrajete alespoň jeden soubor, musíte v tomto kroku vybrat licenci, pod kterou chcete, aby byla vaše data distribuována (data bez licence jsou nepoužitelná, protože uživatel by nevěděl, za jakých podmínek je může používat!)
-                        Prosím přečtěte si pečlivě <a href="./contract">Smlouvu o distribuci dat </a> a klikněte na červené políčko na znamení souhlasu se smlouvou (po kliknutí červené políčko zezelená).
+                        Prosím přečtěte si pečlivě <a href="contract">Smlouvu o distribuci dat </a> a klikněte na červené políčko na znamení souhlasu se smlouvou (po kliknutí červené políčko zezelená).
                         <figure class="print_screen_figure">
 				<img src="assets/images/static-pages/step6_1.png" class="print_screen_img" width="600px" alt="{{'static.deposit.image.step-6-1' | translate}}" />
 				<figcaption>Obr 8. Licence ke smlouvě o distribuci dat</figcaption>
@@ -111,7 +111,7 @@
 
                         I když upřednostňujeme otevřený přístup k datům a otevřený (open source) software, jsme si vědomi toho, že takový přístup není vždy reálný.
                         Můžeme zaručit, že uživatelé musí pro stahování vašich dat podepsat licenci.
-                        (viz <a href="./item-lifecycle#restricted-submissions">Vkládání dat s omezeními</a>).
+                        (viz <a href="static/item-lifecycle#restricted-submissions">Vkládání dat s omezeními</a>).
                         Pokud o uživatelích potřebujete více informací než to, že jsou ověřeni univerzitou (nebo podobnou institucí), můžeme požádat o některá další specifická ověření podobná standardním webovým formulářům. To dává smysl hlavně pro data s licencí, která obsahuje podmínku "nemožnosti další distribuce".
                 </div>
 

--- a/src/static-files/cs/faq.html
+++ b/src/static-files/cs/faq.html
@@ -167,7 +167,7 @@ k dispozici přímo během ukládání dat. Máme k dispozici <a href="./deposit
 	<div>
 		<h3 id="list-of-licenses">Kde najdu více informací o podporovaných licencích?</h3>
 		<p>
-			Seznam licencí, které jsou v současné době podporovány, najdete <a href="no_static_licenses" id="available-licenses">zde.</a>
+			Seznam licencí, které jsou v současné době podporovány, najdete <a href="licenses" id="available-licenses">zde.</a>
 			Pokud potřebujete jinou licenci (např. s elektronickým podpisem apod.), neváhejte nás <a class="helpdesk-tolink" href="#">kontaktovat</a>.
       V případě odůvodněné potřeby jsme schopni přidat do seznamu licencí i takové licence, které jsou doprovázeny různými požadavky, např. omezení na přihlášené uživatele, plnění dalších podrobností (účel) apod.
 		</p>
@@ -217,4 +217,3 @@ Kontakt na "institucionální" Linku podpory pro vaše data je skvělý, ale zá
 		</p>
 	</div>
 </div>
-

--- a/src/static-files/cs/faq.html
+++ b/src/static-files/cs/faq.html
@@ -42,7 +42,7 @@
 Přísně nevyžadujeme, abyste nahráli samotná data, i když je to vždy lepší udělat. V případě potřeby, si můžete uložit pouze samotná metadata.
  Podporujeme také podpis licence on-line cestou pro okamžitou možnost získání zdrojů s omezenou dostupností.</p>
 	<p>
-		Při nahrávání jazykových zdrojů zkuste prosím použít některý z doporučených formátů, uvedených v <a href='http://www.clarin.eu/sites/default/files/Standards%20for%20LRT-v6.pdf'>LRT Standardech</a>.
+		Při nahrávání jazykových zdrojů zkuste prosím použít některý z doporučených formátů, uvedených v <a href='https://standards.clarin.eu/sis/views/recommended-formats-with-search.xq'>CLARIN Standards Information System</a>.
 	</p>
 	</div>
 

--- a/src/static-files/cs/faq.html
+++ b/src/static-files/cs/faq.html
@@ -199,13 +199,13 @@ Kontakt na "institucionální" Linku podpory pro vaše data je skvělý, ale zá
 					padding-bottom:5px;
 				}
 			</style>
-			<dt><a href="../discover?query=PDT+wordnet">PDT wordnet</a> vs <a href="../discover?query=PDT+AND+wordnet">PDT AND wordnet</a></dt>
+			<dt><a href="discover?query=PDT+wordnet">PDT wordnet</a> vs <a href="discover?query=PDT+AND+wordnet">PDT AND wordnet</a></dt>
 			<dd>Defaultním operátorem je OR; tj. první příklad hledá PDT OR wordnet ve všech textových polích.</dd>
-			<dt><a href="../discover?query=dc.title%3AP%3FT+%26%26+-dc.title%3AWordNet">dc.title:P?T &amp;&amp; -dc.title:WordNet</a></dt>
+			<dt><a href="discover?query=dc.title%3AP%3FT+%26%26+-dc.title%3AWordNet">dc.title:P?T &amp;&amp; -dc.title:WordNet</a></dt>
 			<dd>Vrátí všechny položky, které mají P?T v názvu - ? zastupuje jakýkoli  znak (např. PDT) - a nemají v názvu WordNet</dd>
-			<dt><a href="../discover?query=dc.title%3A%22Czech+WordNet%22">dc.title:"Czech WordNet"</a></dt>
+			<dt><a href="discover?query=dc.title%3A%22Czech+WordNet%22">dc.title:"Czech WordNet"</a></dt>
 			<dd>Použijte uvozovky (&quot;) pro přesné shody nebo pro víceslovné výrazy</dd>
-			<dt><a href="../discover?query=author%3A%28Bojar+%26%26+-Tamchyna%29+%26%26+%28dc.language.iso%3A%28ces+AND+eng%29+OR+language%3A%28czech+AND+english%29%29">autor:(Bojar &amp;&amp; -Tamchyna) &amp;&amp; (dc.language.iso:(ces AND eng) OR language:(czech AND english))</a></dt>
+			<dt><a href="discover?query=author%3A%28Bojar+%26%26+-Tamchyna%29+%26%26+%28dc.language.iso%3A%28ces+AND+eng%29+OR+language%3A%28czech+AND+english%29%29">autor:(Bojar &amp;&amp; -Tamchyna) &amp;&amp; (dc.language.iso:(ces AND eng) OR language:(czech AND english))</a></dt>
 			<dd>Hledejte položky od jednoho autora a ne od jiného; zajímavé jsou jen ty položky, které jsou v českém a zároveň anglickém jazyce (např. paralelní korpus).</dd>
 		</dl>
 		</p>

--- a/src/static-files/cs/faq.html
+++ b/src/static-files/cs/faq.html
@@ -4,26 +4,26 @@
 
     <hr />
 	<ul id="faqs-list">
-		<li><a href="#what-is-the-repository">Co je repozitář?</a></li>
-		<li><a href="#what-submissions-do-you-accept">Jaké příspěvky přijímáme?</a></li>
-		<li><a href="#do-i-need-to-create-an-account-to-download-andor-make-a-submission">Musím si vytvořit účet, abych mohl stahovat nebo ukládat data?</a></li>
-		<li><a href="#cant-login">Ukáže se mi chyba při přihlašování</a></li>
-		<li><a href="#why-should-i-submit-my-data-into-your-repository">Proč bych měl ukládat data do repozitáře?</a></li>
-		<li><a href="#why-should-i-submit-my-tools">Proč bych měl ukládat nástroje do repozitáře?</a></li>
-		<li><a href="#what-is-the-handle-good-for">K čemu je dobrý systém Handle (PID)?</a></li>
-		<li><a href="#what-is-deposit-procedure">Jaký je vlastní postup ukládání dat a jejich archivace?</a></li>
-		<li><a href="#how-to-update">Co když chci/potřebuji aktualizovat archivovaná data?</a></li>
-        <li><a href="#how-to-delete">Co když chci v budoucnu svá data odstranit? Mohu je smazat?</a></li>
-		<li><a href="#how-to-lrt-submissions">Začali jsme budovat náš vlastní repozitář, můžeme nějak přesunout záznamy uložené v LRT kolekci?</a></li>
-    <li><a href="#how-to-embargo">Nechci/nemohu mít data veřejně dostupná, anebo je nemohu uveřejnit po určitou dobu. Budete je moci archivovat i za těchto podmínek?</a></li>
-		<li><a href="#how-to-cite">Jak citovat příspěvek?</a></li>
-		<li><a href="#how-safe-is-my-data-if-i-store-it-with-you">Pokud uložím data v repozitáři, jak jsou zabezpečena?</a></li>
-		<li><a href="#what-license-should-i-pick-for-my-datatool">Jakou licenci si mám pro svá data/nástroje vybrat?</a></li>
-		<li><a href="#list-of-licenses">Kde najdu více informací o podporovaných licencích?</a></li>
-		<li><a href="#real-authors">Proč upřednostňujeme skutečné autory před institucemi?</a></li>
-		<li><a href="#searching">Jak získám co nejvíce vyhledávek?</a></li>
-		<li><a href="#new-version">Jak vytvořím novou verzi záznamu?</a></li>
-		<li><a href="#new-version">Jak upravím nahraná data?</a></li>
+		<li><a href="static/faq#what-is-the-repository">Co je repozitář?</a></li>
+		<li><a href="static/faq#what-submissions-do-you-accept">Jaké příspěvky přijímáme?</a></li>
+		<li><a href="static/faq#do-i-need-to-create-an-account-to-download-andor-make-a-submission">Musím si vytvořit účet, abych mohl stahovat nebo ukládat data?</a></li>
+		<li><a href="static/faq#cant-login">Ukáže se mi chyba při přihlašování</a></li>
+		<li><a href="static/faq#why-should-i-submit-my-data-into-your-repository">Proč bych měl ukládat data do repozitáře?</a></li>
+		<li><a href="static/faq#why-should-i-submit-my-tools">Proč bych měl ukládat nástroje do repozitáře?</a></li>
+		<li><a href="static/faq#what-is-the-handle-good-for">K čemu je dobrý systém Handle (PID)?</a></li>
+		<li><a href="static/faq#what-is-deposit-procedure">Jaký je vlastní postup ukládání dat a jejich archivace?</a></li>
+		<li><a href="static/faq#how-to-update">Co když chci/potřebuji aktualizovat archivovaná data?</a></li>
+        <li><a href="static/faq#how-to-delete">Co když chci v budoucnu svá data odstranit? Mohu je smazat?</a></li>
+		<li><a href="static/faq#how-to-lrt-submissions">Začali jsme budovat náš vlastní repozitář, můžeme nějak přesunout záznamy uložené v LRT kolekci?</a></li>
+    <li><a href="static/faq#how-to-embargo">Nechci/nemohu mít data veřejně dostupná, anebo je nemohu uveřejnit po určitou dobu. Budete je moci archivovat i za těchto podmínek?</a></li>
+		<li><a href="static/faq#how-to-cite">Jak citovat příspěvek?</a></li>
+		<li><a href="static/faq#how-safe-is-my-data-if-i-store-it-with-you">Pokud uložím data v repozitáři, jak jsou zabezpečena?</a></li>
+		<li><a href="static/faq#what-license-should-i-pick-for-my-datatool">Jakou licenci si mám pro svá data/nástroje vybrat?</a></li>
+		<li><a href="static/faq#list-of-licenses">Kde najdu více informací o podporovaných licencích?</a></li>
+		<li><a href="static/faq#real-authors">Proč upřednostňujeme skutečné autory před institucemi?</a></li>
+		<li><a href="static/faq#searching">Jak získám co nejvíce vyhledávek?</a></li>
+		<li><a href="static/faq#new-version">Jak vytvořím novou verzi záznamu?</a></li>
+		<li><a href="static/faq#new-version">Jak upravím nahraná data?</a></li>
 	</ul>
     <hr />
 
@@ -140,7 +140,7 @@ administrativní metadata budou zachována a my tak budeme vědět, že vlastní
 
     <div>
 	<h3 id="how-to-cite">Jak citovat příspěvek?</h3>
-	<p>Viz naše <a href="./about">pravidla</a>.</p>
+	<p>Viz naše <a href="static/about">pravidla</a>.</p>
     </div>
 
 	<div>
@@ -159,7 +159,7 @@ administrativní metadata budou zachována a my tak budeme vědět, že vlastní
 	<p>
 		Doporučujeme používat bezplatnou, otevřenou licenci. Reprezentativní výběr bezplatných
 licencí na sofwarové nástroje a CC licencí (vhodnějších pro data) je
-k dispozici přímo během ukládání dat. Máme k dispozici <a href="./deposit#license_selector">OPEN License Selector</a>, který vás provede výběrem vhodných licencí.<BR/>
+k dispozici přímo během ukládání dat. Máme k dispozici <a href="static/deposit#license_selector">OPEN License Selector</a>, který vás provede výběrem vhodných licencí.<BR/>
 		Pokud potřebujete z určitých důvodů jinou licenci, <a class="helpdesk-tolink" href="#">kontaktujte nás</a>.
 	</p>
 	</div>

--- a/src/static-files/cs/item-lifecycle.html
+++ b/src/static-files/cs/item-lifecycle.html
@@ -4,17 +4,17 @@
 
      <hr />
      <ul id="faqs-list">
-         <li><a href="#submitted-item">Nově vložené příspěvky</a></li>
-         <li><a href="#edited-item">Příspěvky procházející kontrolou</a></li>
-         <li><a href="#published-item">Publikované příspěvky</a></li>
-         <li><a href="#modifying-item">Mazání a úprava publikovaných příspěvků</a></li>
-         <li><a href="#restricted-submissions">Příspěvky s omezeními</a></li>
+         <li><a href="static/item-lifecycle#submitted-item">Nově vložené příspěvky</a></li>
+         <li><a href="static/item-lifecycle#edited-item">Příspěvky procházející kontrolou</a></li>
+         <li><a href="static/item-lifecycle#published-item">Publikované příspěvky</a></li>
+         <li><a href="static/item-lifecycle#modifying-item">Mazání a úprava publikovaných příspěvků</a></li>
+         <li><a href="static/item-lifecycle#restricted-submissions">Příspěvky s omezeními</a></li>
      </ul>
      <hr />
 
     <div>
       <h3 id="submitted-item">Nově vložené příspěvky</h3>
-      <p>Jakmile příspěvek <a href="deposit">vložíte</a>, je zařazen do kolekce všech vložených příspěvků. Příspěvek  zatím není veřejně přístupný a čeká, až ho redaktor schválí (nebo zamítne).
+	      <p>Jakmile příspěvek <a href="static/deposit">vložíte</a>, je zařazen do kolekce všech vložených příspěvků. Příspěvek  zatím není veřejně přístupný a čeká, až ho redaktor schválí (nebo zamítne).
       </p>
     </div>
 
@@ -32,7 +32,7 @@
 
       <p>
 
-Publikované příspěvky jsou k dispozici v našem vyhledávacím rozhraní, v režimu prohlížení. Metadata všech datových položek jsou zpřístupněna obecným internetovým vyhledávačům a jsou také k dispozici prostřednictvím protokolu OAI-PMH (mnohé instituce využívají náš repozitář právě pro získání a agregaci uložených metadat), např. <a href="http://catalog.clarin.eu/vlo/">http://catalog.clarin.eu/vlo/</a>). Prostřednictvím protokolu OAI-ORE jsou k dispozici rovněž datové soubory veřejných příspěvků (pro data s omezeným přístupem viz <a href="#restricted-submissions"> Příspěvky s omezeními</a>).
+Publikované příspěvky jsou k dispozici v našem vyhledávacím rozhraní, v režimu prohlížení. Metadata všech datových položek jsou zpřístupněna obecným internetovým vyhledávačům a jsou také k dispozici prostřednictvím protokolu OAI-PMH (mnohé instituce využívají náš repozitář právě pro získání a agregaci uložených metadat), např. <a href="http://catalog.clarin.eu/vlo/">http://catalog.clarin.eu/vlo/</a>). Prostřednictvím protokolu OAI-ORE jsou k dispozici rovněž datové soubory veřejných příspěvků (pro data s omezeným přístupem viz <a href="static/item-lifecycle#restricted-submissions"> Příspěvky s omezeními</a>).
       </p>
    </div>
 
@@ -48,7 +48,7 @@ Publikované příspěvky jsou k dispozici v našem vyhledávacím rozhraní, v 
      Pokud jde o větší změny, vkladatel příspěvku je obvykle vyzván, aby předložil
           <a href="https://github.com/ufal/clarin-dspace/wiki/New-Version-Guide">novou verzi</a>
           příspěvku. Zároveň zařídíme, aby z metadat původní položky vedl odkaz na novou verzi, a původní položka bude pak označena jako "zastaralá".
-      
+
       </p>
     </div>
 

--- a/src/static-files/cs/item-lifecycle.html
+++ b/src/static-files/cs/item-lifecycle.html
@@ -58,11 +58,10 @@ Publikované příspěvky jsou k dispozici v našem vyhledávacím rozhraní, v 
       Podporujeme tedy i takové restriktivní licence pro balíčky souborů s daty, které vyžadují před stahováním "elektronický podpis."
       Tyto elektronické podpisy uchováváme pro případy sporů o porušení práv k duševnímu vlastnictví.</p>
 
-       <p><a href="no_static_licenses">Podívejte se na licence, které jsou v současné době k dispozici,</a> nebo nás <a class="helpdesk-tolink" href="#">kontaktujte</a>, pokud budete chtít nějakou speciální licenci přidat.
+       <p><a href="licenses">Podívejte se na licence, které jsou v současné době k dispozici,</a> nebo nás <a class="helpdesk-tolink" href="#">kontaktujte</a>, pokud budete chtít nějakou speciální licenci přidat.
      </p>
 
       <p>Podporujeme také (dočasné) embargo na balíčky souborů s daty, což znamená, že je zpřístupňujeme veřejnosti až po určité době, kterou můžete při vkládání nastavit.</p>
     </div>
 
 </div>
-

--- a/src/static-files/cs/metadata.html
+++ b/src/static-files/cs/metadata.html
@@ -5,9 +5,9 @@
 
     <hr />
 	<ul id="faqs-list">
-		<li><a href="#formats">Formáty metadat</a></li>
-		<li><a href="#metadata">Vložená metadata</a></li>
-		<li><a href="#mapping">Mapování metadat</a></li>
+		<li><a href="static/metadata#formats">Formáty metadat</a></li>
+		<li><a href="static/metadata#metadata">Vložená metadata</a></li>
+		<li><a href="static/metadata#mapping">Mapování metadat</a></li>
 	</ul>
     <hr />
 	<div>
@@ -28,7 +28,7 @@
 		<p>Podporujeme příspěvky s libovolnými CMDI soubory metadat, které se používají v OAI-PMH, pokud je pro metadata požadováno schéma CMDI.</p>
 		<p>Požadavky ve výše uvedených odstavcích by vás mohly odradit od opakovaného použití <a href="https://catalog.clarin.eu/ds/ComponentRegistry?registrySpace=published&amp;itemId=clarin.eu:cr1:p_1349361150622">clarin.eu:cr1:p_1349361150622</a>. Pro opakované použití jeho specifických komponent ale nezapomínejte, co již bylo o mapování VLO řečeno. <a href="https://catalog.clarin.eu/ds/ComponentRegistry?registrySpace=published&amp;itemId=clarin.eu:cr1:p_1403526079380">clarin.eu:cr1:p_1403526079380</a> s mapováním VLO již počítal při svém vzniku (i když to se může změnit), ale dosud stále odráží náš pohled na svět (jazykových zdrojů) a konkrétní případy použití. Pokud nemáte specifické potřeby, může být toto schéma pro vás dostačující, nebo může být základem pro vaše vlastní schéma.</p>
 		<h4>oai_dc</h4>
-		<p>oai_dc je formát, který je vyžadován schématy <a href="http://www.openarchives.org/OAI/2.0/oai_dc.xsd">OAI-PMH</a>. Mapování našich příspěvků na tento formát vysvětlujeme v <a href="#mapping">sekci o mapování</a>.</p>
+		<p>oai_dc je formát, který je vyžadován schématy <a href="http://www.openarchives.org/OAI/2.0/oai_dc.xsd">OAI-PMH</a>. Mapování našich příspěvků na tento formát vysvětlujeme v <a href="static/metadata#mapping">sekci o mapování</a>.</p>
 	</div>
 	<br/>
 	<div>

--- a/src/static-files/deposit.html
+++ b/src/static-files/deposit.html
@@ -95,7 +95,7 @@ click 'Start Upload'.</p>
                 <p style="margin-top: 10px; margin-bottom: 10px;">If you uploaded at least one file, you must select
                         a license under which you want your resources to be distributed in this step (data without
                         license is unusable because a user does not know how can he/she use it!).
-                        Please read the <a href="./contract">Distribution agreement carefully</a>
+                        Please read the <a href="contract">Distribution agreement carefully</a>
                         and click the red box to indicate your agreement (it will turn green).
                         <figure class="print_screen_figure">
 				<img src="assets/images/static-pages/step6_1.png" class="print_screen_img" width="600px" alt="{{'static.deposit.image.step-6-1' | translate}}" />
@@ -119,7 +119,7 @@ click 'Start Upload'.</p>
 
                         While we prefer open data and open source software, we understand it is not always possible.
                         We can ensure that users must authenticate and sign a license in order to download your data
-                        (see <a href="./item-lifecycle#restricted-submissions">Restricted Submissions</a>).
+                        (see <a href="static/item-lifecycle#restricted-submissions">Restricted Submissions</a>).
                         If you need more information about the users than the fact that they authenticated via a
                         university (or similar), we can ask for some specific attributes similar to standard
                         web forms. This makes sense mostly for data with "no redistribution" clause in their license.

--- a/src/static-files/faq.html
+++ b/src/static-files/faq.html
@@ -242,13 +242,13 @@
 					padding-bottom:5px;
 				}
 			</style>
-			<dt><a href="../discover?query=PDT+wordnet">PDT wordnet</a> vs <a href="../discover?query=PDT+AND+wordnet">PDT AND wordnet</a></dt>
+			<dt><a href="discover?query=PDT+wordnet">PDT wordnet</a> vs <a href="discover?query=PDT+AND+wordnet">PDT AND wordnet</a></dt>
 			<dd>The default operator is OR; ie. the first example searches for PDT OR WordNet in all text fields.</dd>
-			<dt><a href="../discover?query=dc.title%3AP%3FT+%26%26+-dc.title%3AWordNet">dc.title:P?T &amp;&amp; -dc.title:WordNet</a></dt>
+			<dt><a href="discover?query=dc.title%3AP%3FT+%26%26+-dc.title%3AWordNet">dc.title:P?T &amp;&amp; -dc.title:WordNet</a></dt>
 			<dd>Returns all items having P?T in title - ? stands for any character (eg. PDT) - and not having WordNet in the title</dd>
-			<dt><a href="../discover?query=dc.title%3A%22Czech+WordNet%22">dc.title:"Czech WordNet"</a></dt>
+			<dt><a href="discover?query=dc.title%3A%22Czech+WordNet%22">dc.title:"Czech WordNet"</a></dt>
 			<dd>Use double quotes (&quot;) for exact matches and multiword expressions</dd>
-			<dt><a href="../discover?query=author%3A%28Bojar+%26%26+-Tamchyna%29+%26%26+%28dc.language.iso%3A%28ces+AND+eng%29+OR+language%3A%28czech+AND+english%29%29">author:(Bojar &amp;&amp; -Tamchyna) &amp;&amp; (dc.language.iso:(ces AND eng) OR language:(czech AND english))</a></dt>
+			<dt><a href="discover?query=author%3A%28Bojar+%26%26+-Tamchyna%29+%26%26+%28dc.language.iso%3A%28ces+AND+eng%29+OR+language%3A%28czech+AND+english%29%29">author:(Bojar &amp;&amp; -Tamchyna) &amp;&amp; (dc.language.iso:(ces AND eng) OR language:(czech AND english))</a></dt>
 			<dd>Search for items by one author and not the other; interesting are only items about both czech and english languages.</dd>
 		</dl>
 		</p>

--- a/src/static-files/faq.html
+++ b/src/static-files/faq.html
@@ -48,7 +48,7 @@
 		restricted resources.</p>
 	<p>
 		When uploading language resources, please try to use one of the recommended formats
-		mentioned in <a href='http://www.clarin.eu/sites/default/files/Standards%20for%20LRT-v6.pdf'>LRT Standards</a>.
+        mentioned in <a href='https://standards.clarin.eu/sis/views/recommended-formats-with-search.xq'>CLARIN Standards Information System</a>.
 	</p>
 	</div>
 

--- a/src/static-files/faq.html
+++ b/src/static-files/faq.html
@@ -208,7 +208,7 @@
 	<div>
 		<h3 id="list-of-licenses">Where can I find more information about supported licenses?</h3>
 		<p>
-			The list of licenses currently supported is <a href="no_static_licenses" id="available-licenses">here.</a>
+			The list of licenses currently supported is <a href="licenses" id="available-licenses">here.</a>
 			However, do not hesitate to <a class="helpdesk-tolink" href="#">Contact Us</a>
 			in case you need your specific license. The licenses can be accompanied by various requirements; eg. limiting to logged in users, filling additional details (purpose) etc.
 		</p>
@@ -260,4 +260,3 @@
 		</p>
 	</div>
 </div>
-

--- a/src/static-files/faq.html
+++ b/src/static-files/faq.html
@@ -4,25 +4,25 @@
 
     <hr />
 	<ul id="faqs-list">
-		<li><a href="#what-is-the-repository">What is the repository?</a></li>
-		<li><a href="#what-submissions-do-you-accept">What submissions do we accept?</a></li>
-		<li><a href="#do-i-need-to-create-an-account-to-download-andor-make-a-submission">Do I need to create an account to download and/or make a submission?</a></li>
-		<li><a href="#cant-login">I see an error logging in</a></li>
-		<li><a href="#why-should-i-submit-my-data-into-your-repository">Why should I submit my data into your repository?</a></li>
-		<li><a href="#why-should-i-submit-my-tools">Why should I submit my tools?</a></li>
-		<li><a href="#what-is-the-handle-good-for">What is the PID (handle) good for?</a></li>
-		<li><a href="#what-is-deposit-procedure">What is the actual depositing/archiving procedure?</a></li>
-		<li><a href="#how-to-update">What if I want/need to update the archived data?</a></li>
-        <li><a href="#how-to-delete">What if I want to withdraw the resources in the future? Can I delete the data?</a></li>
-		<li><a href="#how-to-lrt-submissions">We have started our own repository, can we somehow move records submitted to the LRT collection?</a></li>
-		<li><a href="#how-to-cite">How to cite a submission?</a></li>
-		<li><a href="#how-safe-is-my-data-if-i-store-it-with-you">How safe is my data if I store it with you?</a></li>
-		<li><a href="#what-license-should-i-pick-for-my-datatool">What license should I pick for my data/tool?</a></li>
-		<li><a href="#list-of-licenses">Where can I find more information about supported licenses?</a></li>
-		<li><a href="#real-authors">Why we strongly prefer real authors to institutions?</a></li>
-		<li><a href="#searching">How do I get the most of my searches?</a></li>
-		<li><a href="#new-version">How do I create a new version of a record?</a></li>
-		<li><a href="#new-version">How do I update the submitted data?</a></li>
+		<li><a href="static/faq#what-is-the-repository">What is the repository?</a></li>
+		<li><a href="static/faq#what-submissions-do-you-accept">What submissions do we accept?</a></li>
+		<li><a href="static/faq#do-i-need-to-create-an-account-to-download-andor-make-a-submission">Do I need to create an account to download and/or make a submission?</a></li>
+		<li><a href="static/faq#cant-login">I see an error logging in</a></li>
+		<li><a href="static/faq#why-should-i-submit-my-data-into-your-repository">Why should I submit my data into your repository?</a></li>
+		<li><a href="static/faq#why-should-i-submit-my-tools">Why should I submit my tools?</a></li>
+		<li><a href="static/faq#what-is-the-handle-good-for">What is the PID (handle) good for?</a></li>
+		<li><a href="static/faq#what-is-deposit-procedure">What is the actual depositing/archiving procedure?</a></li>
+		<li><a href="static/faq#how-to-update">What if I want/need to update the archived data?</a></li>
+        <li><a href="static/faq#how-to-delete">What if I want to withdraw the resources in the future? Can I delete the data?</a></li>
+		<li><a href="static/faq#how-to-lrt-submissions">We have started our own repository, can we somehow move records submitted to the LRT collection?</a></li>
+		<li><a href="static/faq#how-to-cite">How to cite a submission?</a></li>
+		<li><a href="static/faq#how-safe-is-my-data-if-i-store-it-with-you">How safe is my data if I store it with you?</a></li>
+		<li><a href="static/faq#what-license-should-i-pick-for-my-datatool">What license should I pick for my data/tool?</a></li>
+		<li><a href="static/faq#list-of-licenses">Where can I find more information about supported licenses?</a></li>
+		<li><a href="static/faq#real-authors">Why we strongly prefer real authors to institutions?</a></li>
+		<li><a href="static/faq#searching">How do I get the most of my searches?</a></li>
+		<li><a href="static/faq#new-version">How do I create a new version of a record?</a></li>
+		<li><a href="static/faq#new-version">How do I update the submitted data?</a></li>
 	</ul>
     <hr />
 
@@ -175,7 +175,7 @@
 
     <div>
 	<h3 id="how-to-cite">How to cite a submissions?</h3>
-	<p>See our <a href="./about">policies</a>.</p>
+	<p>See our <a href="static/about">policies</a>.</p>
     </div>
 
 	<div>
@@ -200,7 +200,7 @@
 	<p>
 		We encourage using a free license. A representative selection of free
 		licenses as well as CC licenses (more appropriate for data) is
-		available directly during submission. There is a great <a href="./deposit#license_selector">OPEN License Selector</a> which can guide you through the selection of appropriate license.<BR/>
+		available directly during submission. There is a great <a href="static/deposit#license_selector">OPEN License Selector</a> which can guide you through the selection of appropriate license.<BR/>
 		If for some reason you need a different license, <a class="helpdesk-tolink" href="#">Contact Us</a>.
 	</p>
 	</div>

--- a/src/static-files/hplt-dataset-license-1.0.html
+++ b/src/static-files/hplt-dataset-license-1.0.html
@@ -12,7 +12,7 @@
     <p>
       These data are released under this licensing scheme:
     <ul>
-      <li>We do not own any of the text from which these text data has been extracted.<sup><a href="#note1">*</a></sup></li>
+      <li>We do not own any of the text from which these text data has been extracted.<sup><a href="static/hplt-dataset-license-1.0#note1">*</a></sup></li>
       <li>We license the actual packaging of these text data under the <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 license ("no rights reserved")</a>.</li>
     </ul>
     </p>

--- a/src/static-files/item-lifecycle.html
+++ b/src/static-files/item-lifecycle.html
@@ -71,7 +71,7 @@
       <strong>restrictive licences</strong> for bitstreams which require e-signing before downloading the bitstreams.
       We keep track of these e-signatures in case there are IPR infringements.</p>
 
-       <p><a href="no_static_licenses">See currently available licenses</a> or <a class="helpdesk-tolink" href="#">ask us</a>
+       <p><a href="licenses">See currently available licenses</a> or <a class="helpdesk-tolink" href="#">ask us</a>
       to add a specific one.</p>
 
       <p>We also support putting embargo on bitstreams which means that the bitstreams become publicly available
@@ -79,4 +79,3 @@
     </div>
 
 </div>
-

--- a/src/static-files/item-lifecycle.html
+++ b/src/static-files/item-lifecycle.html
@@ -4,17 +4,17 @@
 
      <hr />
      <ul id="faqs-list">
-         <li><a href="#submitted-item">Submitted Item</a></li>
-         <li><a href="#edited-item">Edited Item</a></li>
-         <li><a href="#published-item">Published Item</a></li>
-         <li><a href="#modifying-item">Deleting and Modifying of Published Item</a></li>
-         <li><a href="#restricted-submissions">Restricted submissions</a></li>
+         <li><a href="static/item-lifecycle#submitted-item">Submitted Item</a></li>
+         <li><a href="static/item-lifecycle#edited-item">Edited Item</a></li>
+         <li><a href="static/item-lifecycle#published-item">Published Item</a></li>
+         <li><a href="static/item-lifecycle#modifying-item">Deleting and Modifying of Published Item</a></li>
+         <li><a href="static/item-lifecycle#restricted-submissions">Restricted submissions</a></li>
      </ul>
      <hr />
 
     <div>
       <h3 id="submitted-item">Submitted Item</h3>
-      <p>After you <a href="deposit">deposit</a> a submission it will be inserted into a
+	      <p>After you <a href="static/deposit">deposit</a> a submission it will be inserted into a
       pool of submitted items. The item is not publicly available and waits for an editor
       to approve (or reject) it.
       </p>
@@ -42,7 +42,7 @@
       Published items are available through our search interface, browsing mode. Metadata of all items are submitted to
       search engines and are available through OAI-PMH protocol (several institutes harvest our repository for item's metadata
       e.g., <a href="http://catalog.clarin.eu/vlo/">http://catalog.clarin.eu/vlo/</a>). Bitstreams of public submissions
-          (see <a href="#restricted-submissions">Restricted Submissions</a>) are also available through OAI-ORE protocol.
+          (see <a href="static/item-lifecycle#restricted-submissions">Restricted Submissions</a>) are also available through OAI-ORE protocol.
       </p>
     </div>
 

--- a/src/static-files/metadata.html
+++ b/src/static-files/metadata.html
@@ -5,9 +5,9 @@
 
     <hr />
 	<ul id="faqs-list">
-		<li><a href="#formats">Metadata formats</a></li>
-		<li><a href="#metadata">Submitted metadata</a></li>
-		<li><a href="#mapping">Metadata mapping</a></li>
+		<li><a href="static/metadata#formats">Metadata formats</a></li>
+		<li><a href="static/metadata#metadata">Submitted metadata</a></li>
+		<li><a href="static/metadata#mapping">Metadata mapping</a></li>
 	</ul>
     <hr />
 	<div>
@@ -28,7 +28,7 @@
 		<p>However, we are supporting submissions with arbitrary CMDI metadata files that are used in OAI-PMH when the CMDI metadata profile is requested.</p>
 		<p>Various points in the above paragraphs should discourage you from reusing <a href="https://catalog.clarin.eu/ds/ComponentRegistry?registrySpace=published&amp;itemId=clarin.eu:cr1:p_1349361150622">clarin.eu:cr1:p_1349361150622</a>. For reusing it's specific components, keep in mind what was said above about the VLO mapping. <a href="https://catalog.clarin.eu/ds/ComponentRegistry?registrySpace=published&amp;itemId=clarin.eu:cr1:p_1403526079380">clarin.eu:cr1:p_1403526079380</a> was created with VLO mapping in mind (though this can change), but still reflects our view of the world and our use cases. If you don't gather much more information than is described below, you might find this profile suitable for your needs or as a base for your own one.</p>
 		<h4>oai_dc</h4>
-		<p>oai_dc is the format required by <a href="http://www.openarchives.org/OAI/2.0/oai_dc.xsd">OAI-PMH</a>. See the <a href="#mapping">mapping section</a> in order to understand how we map our submission to this format.</p>
+		<p>oai_dc is the format required by <a href="http://www.openarchives.org/OAI/2.0/oai_dc.xsd">OAI-PMH</a>. See the <a href="static/metadata#mapping">mapping section</a> in order to understand how we map our submission to this format.</p>
 	</div>
 	<br/>
 	<div>


### PR DESCRIPTION
This pull request improves internal link handling for static pages and updates license-related links in static HTML content. The main changes include refactoring the `StaticPageComponent`'s link processing logic for greater robustness and consistency, and updating static files to use the correct license link.

**Improvements to link handling in `StaticPageComponent`:**

- Refactored the `processLinks` method to robustly resolve anchor elements from events, handle nested elements, and consistently build URLs based on the configured namespace. This ensures all internal, relative, and fragment links are handled correctly, and simplifies the code by removing the unused `no_static_` prefix logic.
- Added a helper function in the test suite to simulate link click events, including support for nested elements, and introduced comprehensive tests covering all major link handling scenarios (standard, licenses, relative, fragment, and nested). [[1]](diffhunk://#diff-3c34b44336d2e1e4fc0c74d99f0da529af097e8c6149191442c1ece500afded6R73-R89) [[2]](diffhunk://#diff-3c34b44336d2e1e4fc0c74d99f0da529af097e8c6149191442c1ece500afded6R249-R302)
- Updated the test environment configuration to use the correct `nameSpace` property, matching the main application configuration.

**Content updates in static HTML files:**

- Updated all references to the old `no_static_licenses` link in both English and Czech static HTML files to the correct `licenses` link, ensuring users are directed to the right page for license information. [[1]](diffhunk://#diff-52d6fc4c82cd3b8d20ae3011833de8b3c92ac67a361a8d171494e5394578eacaL68-R68) [[2]](diffhunk://#diff-253a20e81fa30df52a6b4810b927f346f95d056ec5cfd8a9a5e0f222a1694c79L67-R67) [[3]](diffhunk://#diff-b08094e404e2938962228bb667c3ecb9b491e09b5b8c6114364fffb4f9e75ecaL170-R170) [[4]](diffhunk://#diff-8d9b7d53da847eeea2b5dff2f480003e3ad2bb6a74eae0b7d2653e5a105ed890L61-L68) [[5]](diffhunk://#diff-f396cde66c807c41802d60d1817a3698f54b8618abdfacd0721f3cc75559a301L211-R211) [[6]](diffhunk://#diff-de2bd933b92fc91065d5643f133c50739b63215009def6bf9d890f5da4d8a472L74-L82)

**Code cleanup:**

- Removed the unused static property `no_static_` from `StaticPageComponent`.
 
 
## Problem description

1. There's an issue with the /static/about page. The underlying html is @src/static-files/about.html ; when I click the link `<a    id="distribution-link" href="contract">"Distribution License Agreement"</a>` in a browser (links) with disabled js. It works correctly. But in chrome based browsers something interferes. To give a concrete example https://dspace-dev.ufal.mff.cuni.cz/repository/static/about and clicking the link takes me to https://DOMAIN/static/contract (but when I hover over the link I see the correct https://DOMAIN/repository/contract).
2. The no_static_ links don't work without javascript

