### PR TITLE
123 selecting language from dropdown in submission form is broken

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.spec.ts
@@ -170,9 +170,32 @@ describe('DsDynamicAutocompleteComponent test suite', () => {
       autFixture.detectChanges();
       flush();
 
-      expect(autComp.model.value).toEqual(modelValue.display);
+      expect(autComp.model.value).toEqual(modelValue.value);
+      expect(autComp.currentValue).toEqual(modelValue.value);
       expect(autComp.change.emit).toHaveBeenCalled();
     }));
+
+    it('should normalize object value to string on blur', () => {
+      spyOn(autComp.change, 'emit');
+      autComp.currentValue = { value: 'aig', display: 'Alumu-Tesu' };
+
+      autComp.onBlur(new Event('blur'));
+
+      expect(autComp.model.value).toEqual('aig');
+      expect(autComp.change.emit).toHaveBeenCalledWith('aig');
+    });
+
+    it('should format string values as-is', () => {
+      expect(autComp.formatter('aig')).toEqual('aig');
+    });
+
+    it('should format object values using value first', () => {
+      expect(autComp.formatter({ value: 'aig', display: 'Alumu-Tesu' })).toEqual('aig');
+    });
+
+    it('should format object values using display fallback', () => {
+      expect(autComp.formatter({ display: 'Alumu-Tesu' })).toEqual('Alumu-Tesu');
+    });
   });
 });
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.ts
@@ -148,7 +148,6 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
       updateValue.value = this.handlePrefix.value + handle_title[0];
     }
 
-    // this.dispatchUpdate(updateValue.display);
     this.dispatchUpdate(updateValue.value || updateValue.display);
   }
 
@@ -171,7 +170,6 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
     if (init) {
       this.getInitValueFromModel()
         .subscribe((formValue: FormFieldMetadataValueObject) => {
-          // this.currentValue = formValue;
           this.currentValue = formValue?.value || formValue?.display || '';
           this.cdr.detectChanges();
         });
@@ -179,7 +177,6 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
       if (isEmpty(value)) {
         result = '';
       } else {
-        // result = value.value;
         if (typeof value === 'string') {
           result = value;
         } else {
@@ -196,9 +193,6 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
    * Do not show whole suggestion object but just display value.
    * @param x
    */
-  // formatter = (x: { display: string }) => {
-  //   return x.display;
-  // };
   formatter = (x: string | { value?: string; display?: string }) => {
   if (typeof x === 'string') {
       return x;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.ts
@@ -133,7 +133,7 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
    * @param event
    */
   onBlur(event: Event) {
-    this.dispatchUpdate(this.currentValue);
+    this.dispatchUpdate(this.normalizeValue(this.currentValue));
     this.cdr.detectChanges();
   }
 
@@ -148,7 +148,9 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
       updateValue.value = this.handlePrefix.value + handle_title[0];
     }
 
-    this.dispatchUpdate(updateValue.value || updateValue.display);
+    const selectedValue = this.normalizeValue(updateValue);
+    this.currentValue = selectedValue;
+    this.dispatchUpdate(selectedValue);
   }
 
   /**
@@ -170,19 +172,11 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
     if (init) {
       this.getInitValueFromModel()
         .subscribe((formValue: FormFieldMetadataValueObject) => {
-          this.currentValue = formValue?.value || formValue?.display || '';
+          this.currentValue = this.normalizeValue(formValue);
           this.cdr.detectChanges();
         });
     } else {
-      if (isEmpty(value)) {
-        result = '';
-      } else {
-        if (typeof value === 'string') {
-          result = value;
-        } else {
-          result = value?.value || value?.display || '';
-        }
-      }
+      result = isEmpty(value) ? '' : this.normalizeValue(value);
 
       this.currentValue = result;
       this.cdr.detectChanges();
@@ -190,15 +184,24 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
   }
 
   /**
-   * Do not show whole suggestion object but just display value.
-   * @param x
+   * Formats input values for the typeahead.
+   * If x is a string (persisted ISO), return it as-is.
+   * If x is an object, return value first and fallback to display.
+   * @param x raw string/object value from model/typeahead
    */
   formatter = (x: string | { value?: string; display?: string }) => {
-  if (typeof x === 'string') {
-      return x;
-    }
-    return x?.value || x?.display || '';
+    return this.normalizeValue(x);
   };
+
+  /**
+   * Normalize autocomplete values to string.
+   */
+  private normalizeValue(value: string | { value?: string; display?: string }): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+    return value?.value || value?.display || '';
+  }
 
   /**
    * Pretify suggestion.

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component.ts
@@ -148,7 +148,8 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
       updateValue.value = this.handlePrefix.value + handle_title[0];
     }
 
-    this.dispatchUpdate(updateValue.display);
+    // this.dispatchUpdate(updateValue.display);
+    this.dispatchUpdate(updateValue.value || updateValue.display);
   }
 
   /**
@@ -170,14 +171,20 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
     if (init) {
       this.getInitValueFromModel()
         .subscribe((formValue: FormFieldMetadataValueObject) => {
-          this.currentValue = formValue;
+          // this.currentValue = formValue;
+          this.currentValue = formValue?.value || formValue?.display || '';
           this.cdr.detectChanges();
         });
     } else {
       if (isEmpty(value)) {
         result = '';
       } else {
-        result = value.value;
+        // result = value.value;
+        if (typeof value === 'string') {
+          result = value;
+        } else {
+          result = value?.value || value?.display || '';
+        }
       }
 
       this.currentValue = result;
@@ -189,8 +196,14 @@ export class DsDynamicAutocompleteComponent extends DsDynamicTagComponent implem
    * Do not show whole suggestion object but just display value.
    * @param x
    */
-  formatter = (x: { display: string }) => {
-    return x.display;
+  // formatter = (x: { display: string }) => {
+  //   return x.display;
+  // };
+  formatter = (x: string | { value?: string; display?: string }) => {
+  if (typeof x === 'string') {
+      return x;
+    }
+    return x?.value || x?.display || '';
   };
 
   /**


### PR DESCRIPTION
Ensure language autocomplete displays ISO codes consistently after selection and after form reload by handling string values in the input formatter.

## Problem description

In the submission form, the language field (`dc.language.iso`) used an autocomplete input. The behavior was inconsistent:
- When selecting a language from the suggestions, the input displayed the full language name (e.g., `Alumu-Tesu`).
- After saving and reloading the form, the input displayed the ISO code (e.g., `aab`).

The desired behavior is to always display the ISO code (both after selection and after reload) without changing how the metadata is stored.

## Analysis

The root cause was twofold:

1. **Selection path** – The autocomplete component dispatched the `display` field of the selected suggestion, causing the input to show the language name.
2. **Reload path** – The stored metadata (ISO string) was correctly loaded into the component, but the input formatter only handled object‑shaped values, returning an empty string for a plain string.

Initial changes addressed the selection path by:
- `dispatchUpdate(updateValue.value || updateValue.display)` – stores the ISO code on selection.
- `formatter` updated to return `x?.value || x?.display || ''` – works for objects.
- `setCurrentValue` adjusted to use `formValue?.value || formValue?.display || ''` for init.

After these changes, selection worked but reload still showed an empty input because the `formatter` did not support string values (the reload path now provided a plain ISO string). The fix was to extend the formatter to handle both strings and objects.

## Changes

- **`ds-dynamic-autocomplete.component.ts`** – Updated the `formatter` to accept `string | { value?: string; display?: string }` and return the string directly or fallback to `value`/`display`.
- **`ds-dynamic-autocomplete.component.ts`** – Modified `updateModel` to dispatch `value || display`.
- **`ds-dynamic-autocomplete.component.ts`** – Adjusted `setCurrentValue` init branch to assign `currentValue` from `value` first.

These changes are isolated to the autocomplete component and do not alter metadata storage or other fields.

## Manual Testing

- Load a submission with existing language metadata (e.g., `aig`). The input shows the ISO code immediately.
- Type to trigger autocomplete suggestions; select a different language. The input shows the ISO code.
- Save the submission and reload the page. The input still shows the ISO code.
- Repeat with other submission fields to ensure no regressions.

## Copilot review

- [x] Requested review from Copilot