### PR TITLE
 add New version action for archived submission items

### DIFF
--- a/src/app/shared/mydspace-actions/item/item-actions.component.html
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.html
@@ -3,3 +3,12 @@
             [routerLink]="[itemPageRoute]">
   <i class="fa fa-info-circle"></i> {{"submission.workflow.generic.view" | translate}}
 </button>
+
+<button class="btn btn-outline-primary mt-1 mb-3 ml-1"
+        *ngIf="canCreateVersion$ | async"
+        [dsBtnDisabled]="disableNewVersion$ | async"
+        [ngbTooltip]="(newVersionTooltip$ | async) | translate"
+        [attr.aria-label]="(newVersionTooltip$ | async) | translate"
+        (click)="openCreateVersionModal()">
+  <i class="fas fa-code-branch"></i> {{ 'item.page.version.create' | translate }}
+</button>

--- a/src/app/shared/mydspace-actions/item/item-actions.component.spec.ts
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.spec.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Injector, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 
 import { of as observableOf } from 'rxjs';
@@ -16,6 +17,8 @@ import { RequestService } from '../../../core/data/request.service';
 import { getMockSearchService } from '../../mocks/search-service.mock';
 import { getMockRequestService } from '../../mocks/request.service.mock';
 import { SearchService } from '../../../core/shared/search/search.service';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { DsoVersioningModalService } from '../../dso-page/dso-versioning-modal-service/dso-versioning-modal.service';
 
 let component: ItemActionsComponent;
 let fixture: ComponentFixture<ItemActionsComponent>;
@@ -24,7 +27,25 @@ let mockObject: Item;
 
 const mockDataService = {};
 
+const authorizationService = jasmine.createSpyObj('authorizationService', {
+  isAuthorized: observableOf(true),
+});
+
+const dsoVersioningModalService = jasmine.createSpyObj('dsoVersioningModalService', {
+  isNewVersionButtonDisabled: observableOf(false),
+  getVersioningTooltipMessage: observableOf('item.page.version.create'),
+  openCreateVersionModal: undefined,
+});
+
 mockObject = Object.assign(new Item(), {
+  _links: {
+    self: {
+      href: 'https://rest.test/server/api/core/items/item-id'
+    },
+    version: {
+      href: 'https://rest.test/server/api/core/versions/1'
+    }
+  },
   bundles: observableOf({}),
   metadata: {
     'dc.title': [
@@ -76,7 +97,9 @@ describe('ItemActionsComponent', () => {
         { provide: ItemDataService, useValue: mockDataService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: SearchService, useValue: searchService },
-        { provide: RequestService, useValue: requestServce }
+        { provide: RequestService, useValue: requestServce },
+        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: DsoVersioningModalService, useValue: dsoVersioningModalService }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).overrideComponent(ItemActionsComponent, {
@@ -85,6 +108,14 @@ describe('ItemActionsComponent', () => {
   }));
 
   beforeEach(() => {
+    authorizationService.isAuthorized.calls.reset();
+    authorizationService.isAuthorized.and.returnValue(observableOf(true));
+    dsoVersioningModalService.isNewVersionButtonDisabled.calls.reset();
+    dsoVersioningModalService.isNewVersionButtonDisabled.and.returnValue(observableOf(false));
+    dsoVersioningModalService.getVersioningTooltipMessage.calls.reset();
+    dsoVersioningModalService.getVersioningTooltipMessage.and.returnValue(observableOf('item.page.version.create'));
+    dsoVersioningModalService.openCreateVersionModal.calls.reset();
+
     fixture = TestBed.createComponent(ItemActionsComponent);
     component = fixture.componentInstance;
     component.object = mockObject;
@@ -101,6 +132,53 @@ describe('ItemActionsComponent', () => {
     component.initObjects(mockObject);
 
     expect(component.object).toEqual(mockObject);
+  });
+
+  it('should show the New version button when version creation is authorized', () => {
+    fixture.detectChanges();
+
+    const newVersionButton = fixture.debugElement.query(By.css('button.btn-outline-primary'));
+
+    expect(newVersionButton).toBeTruthy();
+  });
+
+  it('should hide the New version button when version creation is not authorized', () => {
+    authorizationService.isAuthorized.and.returnValue(observableOf(false));
+
+    fixture = TestBed.createComponent(ItemActionsComponent);
+    component = fixture.componentInstance;
+    component.object = mockObject;
+    fixture.detectChanges();
+
+    const newVersionButton = fixture.debugElement.query(By.css('button.btn-outline-primary'));
+
+    expect(newVersionButton).toBeNull();
+  });
+
+  it('should mark the New version button as disabled when version creation is disabled', () => {
+    dsoVersioningModalService.isNewVersionButtonDisabled.and.returnValue(observableOf(true));
+
+    fixture = TestBed.createComponent(ItemActionsComponent);
+    component = fixture.componentInstance;
+    component.object = mockObject;
+    fixture.detectChanges();
+
+    let isDisabled: boolean;
+    component.disableNewVersion$.subscribe((value) => {
+      isDisabled = value;
+    });
+
+    expect(isDisabled).toBeTrue();
+  });
+
+  it('should open the create version modal when the New version button is clicked', () => {
+    fixture.detectChanges();
+
+    const newVersionButton = fixture.debugElement.query(By.css('button.btn-outline-primary'));
+
+    newVersionButton.triggerEventHandler('click');
+
+    expect(dsoVersioningModalService.openCreateVersionModal).toHaveBeenCalledWith(mockObject);
   });
 
 });

--- a/src/app/shared/mydspace-actions/item/item-actions.component.spec.ts
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.spec.ts
@@ -171,6 +171,23 @@ describe('ItemActionsComponent', () => {
     expect(isDisabled).toBeTrue();
   });
 
+  it('should derive tooltip from disable state without calling getVersioningTooltipMessage', () => {
+    dsoVersioningModalService.isNewVersionButtonDisabled.and.returnValue(observableOf(true));
+
+    fixture = TestBed.createComponent(ItemActionsComponent);
+    component = fixture.componentInstance;
+    component.object = mockObject;
+    fixture.detectChanges();
+
+    let tooltipKey: string;
+    component.newVersionTooltip$.subscribe((value) => {
+      tooltipKey = value;
+    });
+
+    expect(tooltipKey).toBe('item.page.version.hasDraft');
+    expect(dsoVersioningModalService.getVersioningTooltipMessage).not.toHaveBeenCalled();
+  });
+
   it('should open the create version modal when the New version button is clicked', () => {
     fixture.detectChanges();
 

--- a/src/app/shared/mydspace-actions/item/item-actions.component.ts
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.ts
@@ -2,6 +2,7 @@ import { Component, Injector, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, of as observableOf } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
 import { MyDSpaceActionsComponent } from '../mydspace-actions';
 import { ItemDataService } from '../../../core/data/item-data.service';
 import { Item } from '../../../core/shared/item.model';
@@ -115,7 +116,7 @@ export class ItemActionsComponent extends MyDSpaceActionsComponent<Item, ItemDat
       this.object,
       'item.page.version.hasDraft',
       'item.page.version.create',
-    );
+    ).pipe(shareReplay(1));
   }
 
   /**

--- a/src/app/shared/mydspace-actions/item/item-actions.component.ts
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.ts
@@ -2,7 +2,7 @@ import { Component, Injector, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, of as observableOf } from 'rxjs';
-import { shareReplay } from 'rxjs/operators';
+import { map, shareReplay } from 'rxjs/operators';
 import { MyDSpaceActionsComponent } from '../mydspace-actions';
 import { ItemDataService } from '../../../core/data/item-data.service';
 import { Item } from '../../../core/shared/item.model';
@@ -111,12 +111,10 @@ export class ItemActionsComponent extends MyDSpaceActionsComponent<Item, ItemDat
       FeatureID.CanCreateVersion,
       this.object.self,
     );
-    this.disableNewVersion$ = this.dsoVersioningModalService.isNewVersionButtonDisabled(this.object);
-    this.newVersionTooltip$ = this.dsoVersioningModalService.getVersioningTooltipMessage(
-      this.object,
-      'item.page.version.hasDraft',
-      'item.page.version.create',
-    ).pipe(shareReplay(1));
+    this.disableNewVersion$ = this.dsoVersioningModalService.isNewVersionButtonDisabled(this.object).pipe(shareReplay(1));
+    this.newVersionTooltip$ = this.disableNewVersion$.pipe(
+      map((isDisabled: boolean) => (isDisabled ? 'item.page.version.hasDraft' : 'item.page.version.create')),
+    );
   }
 
   /**

--- a/src/app/shared/mydspace-actions/item/item-actions.component.ts
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.ts
@@ -1,6 +1,7 @@
 import { Component, Injector, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
+import { Observable, of as observableOf } from 'rxjs';
 import { MyDSpaceActionsComponent } from '../mydspace-actions';
 import { ItemDataService } from '../../../core/data/item-data.service';
 import { Item } from '../../../core/shared/item.model';
@@ -8,6 +9,10 @@ import { NotificationsService } from '../../notifications/notifications.service'
 import { RequestService } from '../../../core/data/request.service';
 import { SearchService } from '../../../core/shared/search/search.service';
 import { getItemPageRoute } from '../../../item-page/item-page-routing-paths';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
+import { DsoVersioningModalService } from '../../dso-page/dso-versioning-modal-service/dso-versioning-modal.service';
+import { hasValue } from '../../empty.util';
 
 /**
  * This component represents mydspace actions related to Item object.
@@ -31,6 +36,21 @@ export class ItemActionsComponent extends MyDSpaceActionsComponent<Item, ItemDat
   itemPageRoute: string;
 
   /**
+   * Whether the current user can create a new version for this item.
+   */
+  canCreateVersion$: Observable<boolean>;
+
+  /**
+   * Whether the New version button should be disabled.
+   */
+  disableNewVersion$: Observable<boolean>;
+
+  /**
+   * Tooltip key for the New version button.
+   */
+  newVersionTooltip$: Observable<string>;
+
+  /**
    * Initialize instance variables
    *
    * @param {Injector} injector
@@ -45,12 +65,15 @@ export class ItemActionsComponent extends MyDSpaceActionsComponent<Item, ItemDat
               protected notificationsService: NotificationsService,
               protected translate: TranslateService,
               protected searchService: SearchService,
-              protected requestService: RequestService) {
+              protected requestService: RequestService,
+              protected authorizationService: AuthorizationDataService,
+              protected dsoVersioningModalService: DsoVersioningModalService) {
     super(Item.type, injector, router, notificationsService, translate, searchService, requestService);
   }
 
   ngOnInit(): void {
     this.initPageRoute();
+    this.initVersioningControls();
   }
 
   /**
@@ -61,6 +84,7 @@ export class ItemActionsComponent extends MyDSpaceActionsComponent<Item, ItemDat
   initObjects(object: Item) {
     this.object = object;
     this.initPageRoute();
+    this.initVersioningControls();
   }
 
   /**
@@ -68,6 +92,37 @@ export class ItemActionsComponent extends MyDSpaceActionsComponent<Item, ItemDat
    */
   initPageRoute() {
     this.itemPageRoute = getItemPageRoute(this.object);
+  }
+
+  /**
+   * Initialize authorization and button state for version creation.
+   */
+  initVersioningControls(): void {
+    this.canCreateVersion$ = observableOf(false);
+    this.disableNewVersion$ = observableOf(false);
+    this.newVersionTooltip$ = observableOf('item.page.version.create');
+
+    if (!hasValue(this.object?.self) || !hasValue(this.object?._links?.version?.href)) {
+      return;
+    }
+
+    this.canCreateVersion$ = this.authorizationService.isAuthorized(
+      FeatureID.CanCreateVersion,
+      this.object.self,
+    );
+    this.disableNewVersion$ = this.dsoVersioningModalService.isNewVersionButtonDisabled(this.object);
+    this.newVersionTooltip$ = this.dsoVersioningModalService.getVersioningTooltipMessage(
+      this.object,
+      'item.page.version.hasDraft',
+      'item.page.version.create',
+    );
+  }
+
+  /**
+   * Open the existing Create version modal for the current item.
+   */
+  openCreateVersionModal(): void {
+    this.dsoVersioningModalService.openCreateVersionModal(this.object);
   }
 
 }


### PR DESCRIPTION
## Problem description
On the MyDSpace Your Submissions page, archived item rows only showed the View action.  
The New version action existed on item pages, but not in the submissions list, making version creation harder to discover.

## Analysis
Implemented the minimal scoped solution in ds-item-actions only (archived items), without changing workspace draft actions.

- Added New version button to archived submission actions next to View
- Reused existing versioning flow from DsoVersioningModalService
- Reused existing authorization check CanCreateVersion
- Reused existing tooltip/disabled logic for draft version cases
- Reused existing translation keys:
  - item.page.version.create
  - item.page.version.hasDraft
- Added unit tests for:
  - visibility when authorized
  - hidden state when unauthorized
  - disabled state when draft exists
  - click handler opening create-version modal

### Copilot review
- [x] Requested review from Copilot