### PR TITLE
117 better control of user deletion in user administration page

### DIFF
--- a/src/app/access-control/access-control.module.ts
+++ b/src/app/access-control/access-control.module.ts
@@ -5,6 +5,7 @@ import { SharedModule } from '../shared/shared.module';
 import { AccessControlRoutingModule } from './access-control-routing.module';
 import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
 import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-form.component';
+import { EPersonDeleteGuardService } from './epeople-registry/eperson-delete-guard.service';
 import { GroupFormComponent } from './group-registry/group-form/group-form.component';
 import { MembersListComponent } from './group-registry/group-form/members-list/members-list.component';
 import { SubgroupsListComponent } from './group-registry/group-form/subgroup-list/subgroups-list.component';
@@ -57,6 +58,7 @@ export const ValidateEmailErrorStateMatcher: DynamicErrorMessagesMatcher =
       provide: DYNAMIC_ERROR_MESSAGES_MATCHER,
       useValue: ValidateEmailErrorStateMatcher
     },
+    EPersonDeleteGuardService,
   ]
 })
 /**

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -76,11 +76,22 @@
                           title="{{labelPrefix + 'table.edit.buttons.edit' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
-                  <button *ngIf="epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
-                          class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
-                          title="{{labelPrefix + 'table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
-                    <i class="fas fa-trash-alt fa-fw"></i>
-                  </button>
+                  <ng-container *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton">
+                    <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
+                      <button [dsBtnDisabled]="true"
+                              class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                              type="button">
+                        <i class="fas fa-trash-alt fa-fw"></i>
+                      </button>
+                    </span>
+                  </ng-container>
+                  <ng-template #enabledDeleteButton>
+                    <button *ngIf="epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
+                            class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                            title="{{labelPrefix + 'table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
+                      <i class="fas fa-trash-alt fa-fw"></i>
+                    </button>
+                  </ng-template>
                 </div>
               </td>
             </tr>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -76,17 +76,19 @@
                           title="{{labelPrefix + 'table.edit.buttons.edit' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
-                  <ng-container *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton">
-                    <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
-                      <button [dsBtnDisabled]="true"
-                              class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
-                              type="button">
-                        <i class="fas fa-trash-alt fa-fw"></i>
-                      </button>
-                    </span>
+                  <ng-container *ngIf="epersonDto.ableToDelete && currentAuthenticatedUserId">
+                    <ng-container *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton">
+                      <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
+                        <button [dsBtnDisabled]="true"
+                                class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                                type="button">
+                          <i class="fas fa-trash-alt fa-fw"></i>
+                        </button>
+                      </span>
+                    </ng-container>
                   </ng-container>
                   <ng-template #enabledDeleteButton>
-                    <button *ngIf="epersonDto.ableToDelete && currentAuthenticatedUserId" (click)="deleteEPerson(epersonDto.eperson)"
+                    <button (click)="deleteEPerson(epersonDto.eperson)"
                             class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
                             title="{{labelPrefix + 'table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
                       <i class="fas fa-trash-alt fa-fw"></i>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -80,6 +80,7 @@
                     <ng-container *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton">
                       <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
                         <button [dsBtnDisabled]="true"
+                                tabindex="-1"
                                 class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
                                 type="button">
                           <i class="fas fa-trash-alt fa-fw"></i>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -81,6 +81,7 @@
                       <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
                         <button [dsBtnDisabled]="true"
                                 tabindex="-1"
+                                [attr.aria-label]="selfDeleteWarningLabel | translate"
                                 class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
                                 type="button">
                           <i class="fas fa-trash-alt fa-fw"></i>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -86,7 +86,7 @@
                     </span>
                   </ng-container>
                   <ng-template #enabledDeleteButton>
-                    <button *ngIf="epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
+                    <button *ngIf="epersonDto.ableToDelete && currentAuthenticatedUserId" (click)="deleteEPerson(epersonDto.eperson)"
                             class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
                             title="{{labelPrefix + 'table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
                       <i class="fas fa-trash-alt fa-fw"></i>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -9,14 +9,18 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { buildPaginatedList, PaginatedList } from '../../core/data/paginated-list.model';
 import { RemoteData } from '../../core/data/remote-data';
+import { AuthService } from '../../core/auth/auth.service';
 import { EPersonDataService } from '../../core/eperson/eperson-data.service';
+import { GroupDataService } from '../../core/eperson/group-data.service';
 import { EPerson } from '../../core/eperson/models/eperson.model';
+import { Group } from '../../core/eperson/models/group.model';
 import { PageInfo } from '../../core/shared/page-info.model';
+import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { FormBuilderService } from '../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { EPeopleRegistryComponent } from './epeople-registry.component';
 import { EPersonMock, EPersonMock2 } from '../../shared/testing/eperson.mock';
-import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { getMockFormBuilderService } from '../../shared/mocks/form-builder-service.mock';
 import { getMockTranslateService } from '../../shared/mocks/translate.service.mock';
 import { TranslateLoaderMock } from '../../shared/mocks/translate-loader.mock';
@@ -26,8 +30,13 @@ import { AuthorizationDataService } from '../../core/data/feature-authorization/
 import { RequestService } from '../../core/data/request.service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
 import { FindListOptions } from '../../core/data/find-list-options.model';
-import {BtnDisabledDirective} from '../../shared/btn-disabled.directive';
+import { SearchService } from '../../core/shared/search/search.service';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+import { BtnDisabledDirective } from '../../shared/btn-disabled.directive';
 
 describe('EPeopleRegistryComponent', () => {
   let component: EPeopleRegistryComponent;
@@ -38,9 +47,35 @@ describe('EPeopleRegistryComponent', () => {
   let mockEPeople;
   let ePersonDataServiceStub: any;
   let authorizationService: AuthorizationDataService;
+  let authService: jasmine.SpyObj<AuthService>;
+  let groupDataService: jasmine.SpyObj<GroupDataService>;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
+  let notificationsService: NotificationsServiceStub;
   let modalService;
+  let modalRef;
 
   let paginationService;
+
+  const buildRemoteList = <T>(items: T[], totalElements = items.length) => createSuccessfulRemoteDataObject$(
+    buildPaginatedList(new PageInfo({
+      elementsPerPage: items.length || 1,
+      totalElements,
+      totalPages: 1,
+      currentPage: 1
+    }), items)
+  );
+
+  const buildSearchObjects = (totalElements: number) => Object.assign(
+    new SearchObjects<DSpaceObject>(),
+    buildPaginatedList(new PageInfo({
+      elementsPerPage: 1,
+      totalElements,
+      totalPages: 1,
+      currentPage: 1
+    }), [])
+  );
 
   beforeEach(waitForAsync(() => {
     jasmine.getEnv().allowRespy(true);
@@ -119,8 +154,19 @@ describe('EPeopleRegistryComponent', () => {
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(true)
     });
+    authService = jasmine.createSpyObj('authService', ['getAuthenticatedUserFromStore']);
+    authService.getAuthenticatedUserFromStore.and.returnValue(observableOf(EPersonMock2));
+    groupDataService = jasmine.createSpyObj('groupDataService', ['findListByHref']);
+    groupDataService.findListByHref.and.returnValue(buildRemoteList([], 0));
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
     builderService = getMockFormBuilderService();
     translateService = getMockTranslateService();
+    notificationsService = new NotificationsServiceStub();
 
     paginationService = new PaginationServiceStub();
     TestBed.configureTestingModule({
@@ -135,12 +181,20 @@ describe('EPeopleRegistryComponent', () => {
       declarations: [EPeopleRegistryComponent, BtnDisabledDirective],
       providers: [
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
-        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: NotificationsService, useValue: notificationsService },
         { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: AuthService, useValue: authService },
+        { provide: GroupDataService, useValue: groupDataService },
         { provide: FormBuilderService, useValue: builderService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
         { provide: Router, useValue: new RouterStub() },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) },
-        { provide: PaginationService, useValue: paginationService }
+        { provide: PaginationService, useValue: paginationService },
+        { provide: DSONameService, useValue: jasmine.createSpyObj('dsoNameService', {
+          getName: (dso: any) => dso?.name ?? dso?.email ?? dso?.id,
+        }) },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -150,7 +204,8 @@ describe('EPeopleRegistryComponent', () => {
     fixture = TestBed.createComponent(EPeopleRegistryComponent);
     component = fixture.componentInstance;
     modalService = (component as any).modalService;
-    spyOn(modalService, 'open').and.returnValue(Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) }));
+    modalRef = Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) });
+    spyOn(modalService, 'open').and.returnValue(modalRef);
     fixture.detectChanges();
   });
 
@@ -227,6 +282,66 @@ describe('EPeopleRegistryComponent', () => {
         });
       });
     });
+
+    it('should render the self delete button as disabled', () => {
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+
+      expect(deleteButtons.length).toBe(2);
+      expect(deleteButtons[0].nativeElement.getAttribute('aria-disabled')).toBeNull();
+      expect(deleteButtons[1].nativeElement.getAttribute('aria-disabled')).toBe('true');
+      expect(deleteButtons[1].nativeElement.classList.contains('disabled')).toBeTrue();
+    });
+
+    it('should call submitter checks and compose the combined warning label', fakeAsync(() => {
+      const adminGroup = Object.assign(new Group(), { _name: 'Administrator' });
+      workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([{} as any], 1));
+      workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+      groupDataService.findListByHref.and.returnValue(buildRemoteList([adminGroup], 1));
+      modalRef.componentInstance.response = observableOf(false);
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(workspaceItemDataService.searchBy).toHaveBeenCalledWith('findBySubmitter', jasmine.any(FindListOptions));
+      expect(workflowItemDataService.searchBy).toHaveBeenCalledWith('findBySubmitter', jasmine.any(FindListOptions));
+      expect(searchService.search).toHaveBeenCalled();
+      expect(groupDataService.findListByHref).toHaveBeenCalledWith(EPersonMock._links.groups.href, jasmine.any(FindListOptions));
+      expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    }));
+
+    it('should show a friendly self-delete notification on backend 400 self-delete errors', fakeAsync(() => {
+      modalRef.componentInstance.response = observableOf(true);
+      ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(
+        createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400)
+      );
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    }));
+
+    it('should use the deleted.failure key for generic delete failures', fakeAsync(() => {
+      modalRef.componentInstance.response = observableOf(true);
+      ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(
+        createFailedRemoteDataObject$('server error', 500)
+      );
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.failure');
+    }));
   });
 
   describe('delete EPerson button when the isAuthorized returns false', () => {

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,7 +1,7 @@
 import { Router } from '@angular/router';
 import { Observable, of as observableOf } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
@@ -364,12 +364,9 @@ describe('EPeopleRegistryComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should be disabled', () => {
+    it('should be hidden', () => {
       ePeopleDeleteButton = fixture.debugElement.queryAll(By.css('#epeople tr td div button.delete-button'));
-      ePeopleDeleteButton.forEach((deleteButton: DebugElement) => {
-        expect(deleteButton.nativeElement.getAttribute('aria-disabled')).toBe('true');
-        expect(deleteButton.nativeElement.classList.contains('disabled')).toBeTrue();
-      });
+      expect(ePeopleDeleteButton.length).toBe(0);
     });
   });
 });

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -342,6 +342,18 @@ describe('EPeopleRegistryComponent', () => {
       notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
       expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.failure');
     }));
+
+    it('should not open delete modal before authenticated user id is resolved', fakeAsync(() => {
+      component.currentAuthenticatedUserId = undefined;
+      const deleteSpy = spyOn(ePersonDataServiceStub, 'deleteEPerson').and.callThrough();
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+    }));
   });
 
   describe('delete EPerson button when the isAuthorized returns false', () => {

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,5 +1,5 @@
 import { Router } from '@angular/router';
-import { Observable, of as observableOf } from 'rxjs';
+import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
@@ -11,9 +11,7 @@ import { buildPaginatedList, PaginatedList } from '../../core/data/paginated-lis
 import { RemoteData } from '../../core/data/remote-data';
 import { AuthService } from '../../core/auth/auth.service';
 import { EPersonDataService } from '../../core/eperson/eperson-data.service';
-import { GroupDataService } from '../../core/eperson/group-data.service';
 import { EPerson } from '../../core/eperson/models/eperson.model';
-import { Group } from '../../core/eperson/models/group.model';
 import { PageInfo } from '../../core/shared/page-info.model';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { FormBuilderService } from '../../shared/form/builder/form-builder.service';
@@ -27,6 +25,8 @@ import { TranslateLoaderMock } from '../../shared/mocks/translate-loader.mock';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
 import { RouterStub } from '../../shared/testing/router.stub';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { EPersonDeleteGuardService } from './eperson-delete-guard.service';
 import { RequestService } from '../../core/data/request.service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
@@ -48,7 +48,6 @@ describe('EPeopleRegistryComponent', () => {
   let ePersonDataServiceStub: any;
   let authorizationService: AuthorizationDataService;
   let authService: jasmine.SpyObj<AuthService>;
-  let groupDataService: jasmine.SpyObj<GroupDataService>;
   let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
   let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
   let searchService: jasmine.SpyObj<SearchService>;
@@ -156,8 +155,6 @@ describe('EPeopleRegistryComponent', () => {
     });
     authService = jasmine.createSpyObj('authService', ['getAuthenticatedUserFromStore']);
     authService.getAuthenticatedUserFromStore.and.returnValue(observableOf(EPersonMock2));
-    groupDataService = jasmine.createSpyObj('groupDataService', ['findListByHref']);
-    groupDataService.findListByHref.and.returnValue(buildRemoteList([], 0));
     workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
     workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
     workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
@@ -184,11 +181,11 @@ describe('EPeopleRegistryComponent', () => {
         { provide: NotificationsService, useValue: notificationsService },
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: AuthService, useValue: authService },
-        { provide: GroupDataService, useValue: groupDataService },
         { provide: FormBuilderService, useValue: builderService },
         { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
         { provide: WorkflowItemDataService, useValue: workflowItemDataService },
         { provide: SearchService, useValue: searchService },
+        EPersonDeleteGuardService,
         { provide: Router, useValue: new RouterStub() },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) },
         { provide: PaginationService, useValue: paginationService },
@@ -293,11 +290,10 @@ describe('EPeopleRegistryComponent', () => {
     });
 
     it('should call submitter checks and compose the combined warning label', fakeAsync(() => {
-      const adminGroup = Object.assign(new Group(), { _name: 'Administrator' });
       workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([{} as any], 1));
       workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
       searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
-      groupDataService.findListByHref.and.returnValue(buildRemoteList([adminGroup], 1));
+      // isAuthorized returns true by default -> the target is treated as an administrator
       modalRef.componentInstance.response = observableOf(false);
 
       const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
@@ -307,41 +303,40 @@ describe('EPeopleRegistryComponent', () => {
       expect(workspaceItemDataService.searchBy).toHaveBeenCalledWith('findBySubmitter', jasmine.any(FindListOptions));
       expect(workflowItemDataService.searchBy).toHaveBeenCalledWith('findBySubmitter', jasmine.any(FindListOptions));
       expect(searchService.search).toHaveBeenCalled();
-      expect(groupDataService.findListByHref).toHaveBeenCalledWith(EPersonMock._links.groups.href, jasmine.any(FindListOptions));
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
       expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
     }));
 
-    it('should detect administrator membership on later pages', fakeAsync(() => {
-      const adminGroup = Object.assign(new Group(), { _name: 'Administrator' });
-      const firstPage = createSuccessfulRemoteDataObject$(
-        buildPaginatedList(new PageInfo({
-          elementsPerPage: 100,
-          totalElements: 101,
-          totalPages: 2,
-          currentPage: 1,
-        }), [Object.assign(new Group(), { _name: 'Regular Group' })])
-      );
-      const secondPage = createSuccessfulRemoteDataObject$(
-        buildPaginatedList(new PageInfo({
-          elementsPerPage: 100,
-          totalElements: 101,
-          totalPages: 2,
-          currentPage: 2,
-        }), [adminGroup])
-      );
-
+    it('should detect administrator via the authorization feature', fakeAsync(() => {
       workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
       workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
       searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
-      groupDataService.findListByHref.and.returnValues(firstPage, secondPage);
+      // admin -> true, all submitter probes empty -> admin-only warning
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId === FeatureID.AdministratorOf));
       modalRef.componentInstance.response = observableOf(false);
 
       const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
       deleteButtons[0].triggerEventHandler('click', null);
       tick();
 
-      expect(groupDataService.findListByHref).toHaveBeenCalledTimes(2);
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
       expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.admin');
+    }));
+
+    it('should still open the delete modal when a submitter probe errors (centralised catchError)', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+      // CanDelete stays true so the button renders; AdministratorOf false so the only warning could come from submitter probes
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId !== FeatureID.AdministratorOf));
+      modalRef.componentInstance.response = observableOf(false);
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(modalService.open).toHaveBeenCalled();
+      expect(modalRef.componentInstance.warningLabel).toBeUndefined();
     }));
 
     it('should show a friendly self-delete notification on backend 400 self-delete errors', fakeAsync(() => {

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -311,6 +311,39 @@ describe('EPeopleRegistryComponent', () => {
       expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
     }));
 
+    it('should detect administrator membership on later pages', fakeAsync(() => {
+      const adminGroup = Object.assign(new Group(), { _name: 'Administrator' });
+      const firstPage = createSuccessfulRemoteDataObject$(
+        buildPaginatedList(new PageInfo({
+          elementsPerPage: 100,
+          totalElements: 101,
+          totalPages: 2,
+          currentPage: 1,
+        }), [Object.assign(new Group(), { _name: 'Regular Group' })])
+      );
+      const secondPage = createSuccessfulRemoteDataObject$(
+        buildPaginatedList(new PageInfo({
+          elementsPerPage: 100,
+          totalElements: 101,
+          totalPages: 2,
+          currentPage: 2,
+        }), [adminGroup])
+      );
+
+      workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+      groupDataService.findListByHref.and.returnValues(firstPage, secondPage);
+      modalRef.componentInstance.response = observableOf(false);
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(groupDataService.findListByHref).toHaveBeenCalledTimes(2);
+      expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.admin');
+    }));
+
     it('should show a friendly self-delete notification on backend 400 self-delete errors', fakeAsync(() => {
       modalRef.componentInstance.response = observableOf(true);
       ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -2,12 +2,16 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
-import { map, switchMap, take } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
+import { catchError, map, switchMap, take } from 'rxjs/operators';
+import { AuthService } from '../../core/auth/auth.service';
+import { RequestParam } from '../../core/cache/models/request-param.model';
 import { buildPaginatedList, PaginatedList } from '../../core/data/paginated-list.model';
 import { RemoteData } from '../../core/data/remote-data';
 import { EPersonDataService } from '../../core/eperson/eperson-data.service';
 import { EPerson } from '../../core/eperson/models/eperson.model';
+import { GroupDataService } from '../../core/eperson/group-data.service';
+import { Group } from '../../core/eperson/models/group.model';
 import { hasValue } from '../../shared/empty.util';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
@@ -17,12 +21,19 @@ import { AuthorizationDataService } from '../../core/data/feature-authorization/
 import { getAllSucceededRemoteData, getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { ConfirmationModalComponent } from '../../shared/confirmation-modal/confirmation-modal.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { FindListOptions } from '../../core/data/find-list-options.model';
 import { RequestService } from '../../core/data/request.service';
 import { PageInfo } from '../../core/shared/page-info.model';
 import { NoContent } from '../../core/shared/NoContent.model';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
 import { getEPersonEditRoute, getEPersonsRoute } from '../access-control-routing-paths';
+import { SearchService } from '../../core/shared/search/search.service';
+import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
 
 @Component({
   selector: 'ds-epeople-registry',
@@ -35,6 +46,9 @@ import { getEPersonEditRoute, getEPersonsRoute } from '../access-control-routing
 export class EPeopleRegistryComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.';
+  selfDeleteWarningLabel = this.labelPrefix + 'notification.deleted.forbidden.self';
+
+  currentAuthenticatedUserId: string;
 
   /**
    * A list of all the current EPeople within the repository or the result of the search
@@ -93,10 +107,15 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
               private translateService: TranslateService,
               private notificationsService: NotificationsService,
               private authorizationService: AuthorizationDataService,
+              private authService: AuthService,
+              private groupDataService: GroupDataService,
               private formBuilder: UntypedFormBuilder,
               private router: Router,
               private modalService: NgbModal,
               private paginationService: PaginationService,
+              private workspaceItemDataService: WorkspaceitemDataService,
+              private workflowItemDataService: WorkflowItemDataService,
+              private searchService: SearchService,
               public requestService: RequestService,
               public dsoNameService: DSONameService,
   ) {
@@ -119,6 +138,9 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
     this.searching$.next(true);
     this.search({scope: this.currentSearchScope, query: this.currentSearchQuery});
     this.activeEPerson$ = this.epersonService.getActiveEPerson();
+    this.subs.push(this.authService.getAuthenticatedUserFromStore().subscribe((currentUser: EPerson) => {
+      this.currentAuthenticatedUserId = currentUser?.id;
+    }));
     this.subs.push(this.ePeople$.pipe(
       switchMap((epeople: PaginatedList<EPerson>) => {
         if (epeople.pageInfo.totalElements > 0) {
@@ -135,8 +157,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
             return buildPaginatedList(epeople.pageInfo, dtos);
           }));
         } else {
-          // if it's empty, simply forward the empty list
-          return [epeople];
+          return observableOf(buildPaginatedList(epeople.pageInfo, []));
         }
       })).subscribe((value: PaginatedList<EpersonDtoModel>) => {
       this.searching$.next(false);this.ePeopleDto$.next(value);
@@ -191,28 +212,121 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
    */
   deleteEPerson(ePerson: EPerson) {
     if (hasValue(ePerson.id)) {
-      const modalRef = this.modalService.open(ConfirmationModalComponent);
-      modalRef.componentInstance.dso = ePerson;
-      modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-      modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-      modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-      modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-      modalRef.componentInstance.brandColor = 'danger';
-      modalRef.componentInstance.confirmIcon = 'fas fa-trash';
-      modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
-        if (confirm) {
-          if (hasValue(ePerson.id)) {
+      if (this.isCurrentUser(ePerson)) {
+        this.showSelfDeleteNotification();
+        return;
+      }
+
+      this.getDeleteWarningLabel(ePerson).pipe(take(1)).subscribe((warningLabel: string | undefined) => {
+        const modalRef = this.modalService.open(ConfirmationModalComponent);
+        modalRef.componentInstance.dso = ePerson;
+        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+        modalRef.componentInstance.warningLabel = warningLabel;
+        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+        modalRef.componentInstance.brandColor = 'danger';
+        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+        modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
+          if (confirm) {
             this.epersonService.deleteEPerson(ePerson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
               if (restResponse.hasSucceeded) {
                 this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', {name: this.dsoNameService.getName(ePerson)}));
+              } else if (this.isSelfDeletionError(restResponse)) {
+                this.showSelfDeleteNotification();
               } else {
-                this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { id: ePerson.id, statusCode: restResponse.statusCode, errorMessage: restResponse.errorMessage }));
+                this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
+                  id: ePerson.id,
+                  statusCode: restResponse.statusCode,
+                  errorMessage: restResponse.errorMessage,
+                  restResponse,
+                }));
               }
             });
           }
-        }
+        });
       });
     }
+  }
+
+  isCurrentUser(ePerson: EPerson): boolean {
+    return hasValue(ePerson?.id) && ePerson.id === this.currentAuthenticatedUserId;
+  }
+
+  private getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
+    return combineLatest([
+      this.hasSubmittedItems(ePerson.id),
+      this.isAdministrator(ePerson),
+    ]).pipe(
+      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
+        if (hasSubmittedItems && isAdmin) {
+          return this.labelPrefix + 'delete.warning.submitterAndAdmin';
+        }
+        if (hasSubmittedItems) {
+          return this.labelPrefix + 'delete.warning.submitter';
+        }
+        if (isAdmin) {
+          return this.labelPrefix + 'delete.warning.admin';
+        }
+        return undefined;
+      })
+    );
+  }
+
+  private hasSubmittedItems(epersonId: string): Observable<boolean> {
+    const submitterSearchOptions = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 1,
+      searchParams: [new RequestParam('uuid', epersonId)],
+    });
+    const archivedSearchOptions = new PaginatedSearchOptions({
+      query: `submitter_authority:${epersonId}`,
+      pagination: Object.assign(new PaginationComponentOptions(), {
+        currentPage: 1,
+        pageSize: 1,
+      }),
+    });
+
+    return combineLatest([
+      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false))
+      ),
+      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false))
+      ),
+      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false))
+      ),
+    ]).pipe(
+      map((results: boolean[]) => results.some(Boolean))
+    );
+  }
+
+  private isAdministrator(ePerson: EPerson): Observable<boolean> {
+    const options = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 100,
+    });
+
+    return this.groupDataService.findListByHref(ePerson._links.groups.href, options).pipe(
+      getFirstCompletedRemoteData(),
+      map((rd: RemoteData<PaginatedList<Group>>) => rd.hasSucceeded && rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator')),
+      catchError(() => observableOf(false))
+    );
+  }
+
+  private isSelfDeletionError(restResponse: RemoteData<NoContent>): boolean {
+    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
+  }
+
+  private showSelfDeleteNotification(): void {
+    this.notificationsService.error(this.translateService.get(this.selfDeleteWarningLabel));
   }
 
   /**

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -228,6 +228,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
                 this.deleteGuard.showSelfDeleteNotification();
               } else {
                 this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
+                  name: this.dsoNameService.getName(ePerson),
                   id: ePerson.id,
                   statusCode: restResponse.statusCode,
                   errorMessage: restResponse.errorMessage,

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -212,6 +212,10 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
    */
   deleteEPerson(ePerson: EPerson) {
     if (hasValue(ePerson.id)) {
+      if (!hasValue(this.currentAuthenticatedUserId)) {
+        return;
+      }
+
       if (this.isCurrentUser(ePerson)) {
         this.showSelfDeleteNotification();
         return;

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -313,14 +313,34 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
   }
 
   private isAdministrator(ePerson: EPerson): Observable<boolean> {
+    return this.hasAdministratorGroupOnPage(ePerson._links.groups.href, 1);
+  }
+
+  private hasAdministratorGroupOnPage(groupsHref: string, currentPage: number): Observable<boolean> {
     const options = Object.assign(new FindListOptions(), {
-      currentPage: 1,
+      currentPage,
       elementsPerPage: 100,
     });
 
-    return this.groupDataService.findListByHref(ePerson._links.groups.href, options).pipe(
+    return this.groupDataService.findListByHref(groupsHref, options).pipe(
       getFirstCompletedRemoteData(),
-      map((rd: RemoteData<PaginatedList<Group>>) => rd.hasSucceeded && rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator')),
+      switchMap((rd: RemoteData<PaginatedList<Group>>) => {
+        if (!rd?.hasSucceeded || !hasValue(rd.payload)) {
+          return observableOf(false);
+        }
+
+        const hasAdministrator = rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator');
+        if (hasAdministrator) {
+          return observableOf(true);
+        }
+
+        const hasMorePages = rd.payload.pageInfo.currentPage < rd.payload.pageInfo.totalPages;
+        if (!hasMorePages) {
+          return observableOf(false);
+        }
+
+        return this.hasAdministratorGroupOnPage(groupsHref, rd.payload.pageInfo.currentPage + 1);
+      }),
       catchError(() => observableOf(false))
     );
   }

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -3,15 +3,12 @@ import { UntypedFormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
-import { catchError, map, switchMap, take } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 import { AuthService } from '../../core/auth/auth.service';
-import { RequestParam } from '../../core/cache/models/request-param.model';
 import { buildPaginatedList, PaginatedList } from '../../core/data/paginated-list.model';
 import { RemoteData } from '../../core/data/remote-data';
 import { EPersonDataService } from '../../core/eperson/eperson-data.service';
 import { EPerson } from '../../core/eperson/models/eperson.model';
-import { GroupDataService } from '../../core/eperson/group-data.service';
-import { Group } from '../../core/eperson/models/group.model';
 import { hasValue } from '../../shared/empty.util';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
@@ -21,19 +18,13 @@ import { AuthorizationDataService } from '../../core/data/feature-authorization/
 import { getAllSucceededRemoteData, getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { ConfirmationModalComponent } from '../../shared/confirmation-modal/confirmation-modal.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { FindListOptions } from '../../core/data/find-list-options.model';
 import { RequestService } from '../../core/data/request.service';
 import { PageInfo } from '../../core/shared/page-info.model';
 import { NoContent } from '../../core/shared/NoContent.model';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
-import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
-import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
 import { getEPersonEditRoute, getEPersonsRoute } from '../access-control-routing-paths';
-import { SearchService } from '../../core/shared/search/search.service';
-import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
-import { DSpaceObject } from '../../core/shared/dspace-object.model';
-import { SearchObjects } from '../../shared/search/models/search-objects.model';
+import { EPersonDeleteGuardService, SELF_DELETE_WARNING_LABEL } from './eperson-delete-guard.service';
 
 @Component({
   selector: 'ds-epeople-registry',
@@ -46,7 +37,7 @@ import { SearchObjects } from '../../shared/search/models/search-objects.model';
 export class EPeopleRegistryComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.';
-  selfDeleteWarningLabel = this.labelPrefix + 'notification.deleted.forbidden.self';
+  selfDeleteWarningLabel = SELF_DELETE_WARNING_LABEL;
 
   currentAuthenticatedUserId: string;
 
@@ -108,14 +99,11 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
               private notificationsService: NotificationsService,
               private authorizationService: AuthorizationDataService,
               private authService: AuthService,
-              private groupDataService: GroupDataService,
+              private deleteGuard: EPersonDeleteGuardService,
               private formBuilder: UntypedFormBuilder,
               private router: Router,
               private modalService: NgbModal,
               private paginationService: PaginationService,
-              private workspaceItemDataService: WorkspaceitemDataService,
-              private workflowItemDataService: WorkflowItemDataService,
-              private searchService: SearchService,
               public requestService: RequestService,
               public dsoNameService: DSONameService,
   ) {
@@ -217,11 +205,11 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
       }
 
       if (this.isCurrentUser(ePerson)) {
-        this.showSelfDeleteNotification();
+        this.deleteGuard.showSelfDeleteNotification();
         return;
       }
 
-      this.getDeleteWarningLabel(ePerson).pipe(take(1)).subscribe((warningLabel: string | undefined) => {
+      this.deleteGuard.getDeleteWarningLabel(ePerson).pipe(take(1)).subscribe((warningLabel: string | undefined) => {
         const modalRef = this.modalService.open(ConfirmationModalComponent);
         modalRef.componentInstance.dso = ePerson;
         modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
@@ -236,8 +224,8 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
             this.epersonService.deleteEPerson(ePerson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
               if (restResponse.hasSucceeded) {
                 this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', {name: this.dsoNameService.getName(ePerson)}));
-              } else if (this.isSelfDeletionError(restResponse)) {
-                this.showSelfDeleteNotification();
+              } else if (this.deleteGuard.isSelfDeletionError(restResponse)) {
+                this.deleteGuard.showSelfDeleteNotification();
               } else {
                 this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
                   id: ePerson.id,
@@ -254,103 +242,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
   }
 
   isCurrentUser(ePerson: EPerson): boolean {
-    return hasValue(ePerson?.id) && ePerson.id === this.currentAuthenticatedUserId;
-  }
-
-  private getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
-    return combineLatest([
-      this.hasSubmittedItems(ePerson.id),
-      this.isAdministrator(ePerson),
-    ]).pipe(
-      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
-        if (hasSubmittedItems && isAdmin) {
-          return this.labelPrefix + 'delete.warning.submitterAndAdmin';
-        }
-        if (hasSubmittedItems) {
-          return this.labelPrefix + 'delete.warning.submitter';
-        }
-        if (isAdmin) {
-          return this.labelPrefix + 'delete.warning.admin';
-        }
-        return undefined;
-      })
-    );
-  }
-
-  private hasSubmittedItems(epersonId: string): Observable<boolean> {
-    const submitterSearchOptions = Object.assign(new FindListOptions(), {
-      currentPage: 1,
-      elementsPerPage: 1,
-      searchParams: [new RequestParam('uuid', epersonId)],
-    });
-    const archivedSearchOptions = new PaginatedSearchOptions({
-      query: `submitter_authority:${epersonId}`,
-      pagination: Object.assign(new PaginationComponentOptions(), {
-        currentPage: 1,
-        pageSize: 1,
-      }),
-    });
-
-    return combineLatest([
-      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
-        catchError(() => observableOf(false))
-      ),
-      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
-        catchError(() => observableOf(false))
-      ),
-      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
-        catchError(() => observableOf(false))
-      ),
-    ]).pipe(
-      map((results: boolean[]) => results.some(Boolean))
-    );
-  }
-
-  private isAdministrator(ePerson: EPerson): Observable<boolean> {
-    return this.hasAdministratorGroupOnPage(ePerson._links.groups.href, 1);
-  }
-
-  private hasAdministratorGroupOnPage(groupsHref: string, currentPage: number): Observable<boolean> {
-    const options = Object.assign(new FindListOptions(), {
-      currentPage,
-      elementsPerPage: 100,
-    });
-
-    return this.groupDataService.findListByHref(groupsHref, options).pipe(
-      getFirstCompletedRemoteData(),
-      switchMap((rd: RemoteData<PaginatedList<Group>>) => {
-        if (!rd?.hasSucceeded || !hasValue(rd.payload)) {
-          return observableOf(false);
-        }
-
-        const hasAdministrator = rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator');
-        if (hasAdministrator) {
-          return observableOf(true);
-        }
-
-        const hasMorePages = rd.payload.pageInfo.currentPage < rd.payload.pageInfo.totalPages;
-        if (!hasMorePages) {
-          return observableOf(false);
-        }
-
-        return this.hasAdministratorGroupOnPage(groupsHref, rd.payload.pageInfo.currentPage + 1);
-      }),
-      catchError(() => observableOf(false))
-    );
-  }
-
-  private isSelfDeletionError(restResponse: RemoteData<NoContent>): boolean {
-    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
-  }
-
-  private showSelfDeleteNotification(): void {
-    this.notificationsService.error(this.translateService.get(this.selfDeleteWarningLabel));
+    return this.deleteGuard.isCurrentUser(ePerson, this.currentAuthenticatedUserId);
   }
 
   /**

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.spec.ts
@@ -1,0 +1,147 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { buildPaginatedList } from '../../core/data/paginated-list.model';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchService } from '../../core/shared/search/search.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
+import { EPersonMock } from '../../shared/testing/eperson.mock';
+import { EPersonDeleteGuardService } from './eperson-delete-guard.service';
+
+describe('EPersonDeleteGuardService', () => {
+  let service: EPersonDeleteGuardService;
+  let authorizationService: jasmine.SpyObj<AuthorizationDataService>;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
+  let notificationsService: NotificationsServiceStub;
+  let translateService: jasmine.SpyObj<TranslateService>;
+
+  const remoteList = (totalElements: number) => createSuccessfulRemoteDataObject$(
+    buildPaginatedList(new PageInfo({ elementsPerPage: 1, totalElements, totalPages: 1, currentPage: 1 }), [])
+  );
+  const searchObjects = (totalElements: number) => createSuccessfulRemoteDataObject$(Object.assign(
+    new SearchObjects<DSpaceObject>(),
+    buildPaginatedList(new PageInfo({ elementsPerPage: 1, totalElements, totalPages: 1, currentPage: 1 }), [])
+  ));
+
+  beforeEach(() => {
+    authorizationService = jasmine.createSpyObj('authorizationService', ['isAuthorized']);
+    authorizationService.isAuthorized.and.returnValue(observableOf(false));
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(remoteList(0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(remoteList(0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(searchObjects(0));
+    notificationsService = new NotificationsServiceStub();
+    translateService = jasmine.createSpyObj('translateService', ['get']);
+    translateService.get.and.callFake((key: string) => observableOf(key));
+
+    TestBed.configureTestingModule({
+      providers: [
+        EPersonDeleteGuardService,
+        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
+        { provide: NotificationsService, useValue: notificationsService },
+        { provide: TranslateService, useValue: translateService },
+      ],
+    });
+    service = TestBed.inject(EPersonDeleteGuardService);
+  });
+
+  describe('isCurrentUser', () => {
+    it('is true only when the ids match', () => {
+      expect(service.isCurrentUser(EPersonMock, EPersonMock.id)).toBeTrue();
+      expect(service.isCurrentUser(EPersonMock, 'someone-else')).toBeFalse();
+      expect(service.isCurrentUser(undefined, EPersonMock.id)).toBeFalsy();
+    });
+  });
+
+  describe('getDeleteWarningLabel', () => {
+    it('returns undefined when the user is neither a submitter nor an admin', fakeAsync(() => {
+      let label: string | undefined = 'unset';
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBeUndefined();
+    }));
+
+    it('returns the submitter warning when the user has submitted items', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(remoteList(1));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBe('admin.access-control.epeople.delete.warning.submitter');
+    }));
+
+    it('returns the admin warning, querying the AdministratorOf feature for the target user', fakeAsync(() => {
+      authorizationService.isAuthorized.and.returnValue(observableOf(true));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
+      expect(label).toBe('admin.access-control.epeople.delete.warning.admin');
+    }));
+
+    it('returns the combined warning when both apply', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(remoteList(1));
+      authorizationService.isAuthorized.and.returnValue(observableOf(true));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    }));
+
+    it('degrades each probe to false on error so a failed lookup never blocks the delete', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      searchService.search.and.returnValue(observableThrowError(() => new Error('boom')));
+      authorizationService.isAuthorized.and.returnValue(observableThrowError(() => new Error('boom')));
+      let emitted = false;
+      let label: string | undefined = 'unset';
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => {
+        emitted = true;
+        label = value;
+      });
+      tick();
+      expect(emitted).toBeTrue();
+      expect(label).toBeUndefined();
+    }));
+  });
+
+  describe('isSelfDeletionError', () => {
+    it('recognises the backend self-delete rejection', fakeAsync(() => {
+      let rd;
+      createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400).subscribe((value) => rd = value);
+      tick();
+      expect(service.isSelfDeletionError(rd)).toBeTrue();
+    }));
+
+    it('ignores other failures', fakeAsync(() => {
+      let rd;
+      createFailedRemoteDataObject$('server error', 500).subscribe((value) => rd = value);
+      tick();
+      expect(service.isSelfDeletionError(rd)).toBeFalsy();
+      expect(service.isSelfDeletionError(null)).toBeFalsy();
+    }));
+  });
+
+  describe('showSelfDeleteNotification', () => {
+    it('emits the self-delete error notification', () => {
+      service.showSelfDeleteNotification();
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    });
+  });
+});

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { RequestParam } from '../../core/cache/models/request-param.model';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { FindListOptions } from '../../core/data/find-list-options.model';
+import { PaginatedList } from '../../core/data/paginated-list.model';
+import { RemoteData } from '../../core/data/remote-data';
+import { EPerson } from '../../core/eperson/models/eperson.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { NoContent } from '../../core/shared/NoContent.model';
+import { getFirstCompletedRemoteData } from '../../core/shared/operators';
+import { SearchService } from '../../core/shared/search/search.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { hasValue } from '../../shared/empty.util';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+
+/**
+ * Translation key for the notification shown when an admin tries to delete their own account.
+ * Exported so the templates can bind it as the disabled-delete-button tooltip.
+ */
+export const SELF_DELETE_WARNING_LABEL = 'admin.access-control.epeople.notification.deleted.forbidden.self';
+
+const WARNING_LABEL_PREFIX = 'admin.access-control.epeople.delete.warning.';
+
+/**
+ * Shared logic for the EPerson delete flow used by both the EPeople registry and the EPerson form.
+ * Determines a contextual warning for high-impact deletes, recognises the backend self-delete error
+ * and surfaces the self-delete notification. Centralised here so both call sites stay in sync
+ * (the previous per-component copies had already diverged in their error handling).
+ */
+@Injectable()
+export class EPersonDeleteGuardService {
+
+  constructor(
+    private authorizationService: AuthorizationDataService,
+    private workspaceItemDataService: WorkspaceitemDataService,
+    private workflowItemDataService: WorkflowItemDataService,
+    private searchService: SearchService,
+    private notificationsService: NotificationsService,
+    private translateService: TranslateService,
+  ) {
+  }
+
+  /**
+   * Whether the given EPerson is the currently authenticated user.
+   */
+  isCurrentUser(ePerson: EPerson, currentAuthenticatedUserId: string): boolean {
+    return hasValue(ePerson?.id) && ePerson.id === currentAuthenticatedUserId;
+  }
+
+  /**
+   * Resolve the contextual warning translation key for deleting the given EPerson,
+   * or undefined when there is nothing noteworthy to warn about.
+   * Warns when the user has submitted items, is an administrator, or both.
+   */
+  getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
+    return combineLatest([
+      this.hasSubmittedItems(ePerson.id),
+      this.isAdministrator(ePerson),
+    ]).pipe(
+      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
+        if (hasSubmittedItems && isAdmin) {
+          return WARNING_LABEL_PREFIX + 'submitterAndAdmin';
+        }
+        if (hasSubmittedItems) {
+          return WARNING_LABEL_PREFIX + 'submitter';
+        }
+        if (isAdmin) {
+          return WARNING_LABEL_PREFIX + 'admin';
+        }
+        return undefined;
+      })
+    );
+  }
+
+  /**
+   * Whether the backend rejected the delete because an admin tried to delete themselves.
+   */
+  isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
+    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
+  }
+
+  /**
+   * Show the "you cannot delete your own account" error notification.
+   */
+  showSelfDeleteNotification(): void {
+    this.notificationsService.error(this.translateService.get(SELF_DELETE_WARNING_LABEL));
+  }
+
+  /**
+   * Whether the EPerson is the submitter of any workspace, workflow or archived item.
+   * Each lookup degrades to `false` on error so a failed probe never blocks the delete.
+   */
+  private hasSubmittedItems(epersonId: string): Observable<boolean> {
+    const submitterSearchOptions = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 1,
+      searchParams: [new RequestParam('uuid', epersonId)],
+    });
+    const archivedSearchOptions = new PaginatedSearchOptions({
+      query: `submitter_authority:${epersonId}`,
+      pagination: Object.assign(new PaginationComponentOptions(), {
+        currentPage: 1,
+        pageSize: 1,
+      }),
+    });
+
+    return combineLatest([
+      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+    ]).pipe(
+      map((results: boolean[]) => results.some(Boolean)),
+    );
+  }
+
+  /**
+   * Whether the EPerson is a site administrator, via the authorization feature
+   * (catches indirect admin rights and avoids matching on a hard-coded group name).
+   */
+  private isAdministrator(ePerson: EPerson): Observable<boolean> {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf, undefined, ePerson?.id).pipe(
+      catchError(() => observableOf(false)),
+    );
+  }
+}

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -37,7 +37,7 @@
             <i class="fa fa-user-secret"></i> {{'admin.access-control.epeople.actions.stop-impersonating' | translate}}
           </button>
         </div>
-        <span after *ngIf="(canDelete$ | async) && (activeEPerson$ | async) as activeEPerson">
+        <span *ngIf="(canDelete$ | async) && (activeEPerson$ | async) as activeEPerson">
           <span *ngIf="isCurrentUser(activeEPerson); else enabledDeleteButton"
                 tabindex="0"
                 [ngbTooltip]="selfDeleteWarningLabel | translate">

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -46,7 +46,7 @@
             </button>
           </span>
           <ng-template #enabledDeleteButton>
-            <button class="btn btn-danger delete-button" type="button" (click)="delete()">
+            <button *ngIf="currentAuthenticatedUserId" class="btn btn-danger delete-button" type="button" (click)="delete()">
               <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
             </button>
           </ng-template>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -37,9 +37,20 @@
             <i class="fa fa-user-secret"></i> {{'admin.access-control.epeople.actions.stop-impersonating' | translate}}
           </button>
         </div>
-        <button *ngIf="canDelete$ | async" after class="btn btn-danger delete-button" type="button" (click)="delete()">
-          <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
-        </button>
+        <span after *ngIf="(canDelete$ | async) && (activeEPerson$ | async) as activeEPerson">
+          <span *ngIf="isCurrentUser(activeEPerson); else enabledDeleteButton"
+                tabindex="0"
+                [ngbTooltip]="selfDeleteWarningLabel | translate">
+            <button class="btn btn-danger delete-button" [dsBtnDisabled]="true" type="button">
+              <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
+            </button>
+          </span>
+          <ng-template #enabledDeleteButton>
+            <button class="btn btn-danger delete-button" type="button" (click)="delete()">
+              <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
+            </button>
+          </ng-template>
+        </span>
       </ds-form>
 
       <ds-themed-loading [showMessage]="false" *ngIf="!formGroup"></ds-themed-loading>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -41,7 +41,7 @@
           <span *ngIf="isCurrentUser(activeEPerson); else enabledDeleteButton"
                 tabindex="0"
                 [ngbTooltip]="selfDeleteWarningLabel | translate">
-            <button class="btn btn-danger delete-button" [dsBtnDisabled]="true" type="button">
+            <button class="btn btn-danger delete-button" [dsBtnDisabled]="true" tabindex="-1" type="button">
               <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
             </button>
           </span>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -10,13 +10,14 @@ import { buildPaginatedList, PaginatedList } from '../../../core/data/paginated-
 import { RemoteData } from '../../../core/data/remote-data';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
+import { Group } from '../../../core/eperson/models/group.model';
 import { PageInfo } from '../../../core/shared/page-info.model';
 import { FormBuilderService } from '../../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
 import { EPeopleRegistryComponent } from '../epeople-registry.component';
 import { EPersonFormComponent } from './eperson-form.component';
 import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson.mock';
-import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { getMockFormBuilderService } from '../../../shared/mocks/form-builder-service.mock';
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 import { AuthService } from '../../../core/auth/auth.service';
@@ -35,7 +36,13 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { RouterStub } from '../../../shared/testing/router.stub';
 import { ActivatedRouteStub } from '../../../shared/testing/active-router.stub';
 import { RouterTestingModule } from '@angular/router/testing';
-import {BtnDisabledDirective} from '../../../shared/btn-disabled.directive';
+import { BtnDisabledDirective } from '../../../shared/btn-disabled.directive';
+import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
+import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
+import { SearchService } from '../../../core/shared/search/search.service';
+import { SearchObjects } from '../../../shared/search/models/search-objects.model';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 
 describe('EPersonFormComponent', () => {
   let component: EPersonFormComponent;
@@ -50,12 +57,34 @@ describe('EPersonFormComponent', () => {
   let epersonRegistrationService: EpersonRegistrationService;
   let route: ActivatedRouteStub;
   let router: RouterStub;
+  let notificationsService: NotificationsServiceStub;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
 
   let paginationService;
 
 
 
   beforeEach(waitForAsync(() => {
+    const buildRemoteList = <T>(items: T[], totalElements = items.length) => createSuccessfulRemoteDataObject$(
+      buildPaginatedList(new PageInfo({
+        elementsPerPage: items.length || 1,
+        totalElements,
+        totalPages: 1,
+        currentPage: 1,
+      }), items)
+    );
+    const buildSearchObjects = (totalElements: number) => Object.assign(
+      new SearchObjects<DSpaceObject>(),
+      buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements,
+        totalPages: 1,
+        currentPage: 1,
+      }), [])
+    );
+
     mockEPeople = [EPersonMock, EPersonMock2];
     ePersonDataServiceStub = {
       activeEPerson: null,
@@ -178,7 +207,9 @@ describe('EPersonFormComponent', () => {
         return typeof value === 'object' && value !== null;
       }
     });
-    authService = new AuthServiceStub();
+    authService = Object.assign(new AuthServiceStub(), {
+      getAuthenticatedUserFromStore: () => observableOf(EPersonMock),
+    });
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(true),
 
@@ -187,6 +218,13 @@ describe('EPersonFormComponent', () => {
       findListByHref: createSuccessfulRemoteDataObject$(createPaginatedList([])),
       getGroupRegistryRouterLink: ''
     });
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+    notificationsService = new NotificationsServiceStub();
 
     paginationService = new PaginationServiceStub();
     route = new ActivatedRouteStub();
@@ -201,12 +239,18 @@ describe('EPersonFormComponent', () => {
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: GroupDataService, useValue: groupsDataService },
         { provide: FormBuilderService, useValue: builderService },
-        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: NotificationsService, useValue: notificationsService },
         { provide: AuthService, useValue: authService },
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: PaginationService, useValue: paginationService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring'])},
         { provide: EpersonRegistrationService, useValue: epersonRegistrationService },
+        { provide: DSONameService, useValue: jasmine.createSpyObj('dsoNameService', {
+          getName: (dso: any) => dso?.name ?? dso?.email ?? dso?.id,
+        }) },
         { provide: ActivatedRoute, useValue: route },
         { provide: Router, useValue: router },
         EPeopleRegistryComponent
@@ -448,7 +492,7 @@ describe('EPersonFormComponent', () => {
 
     beforeEach(() => {
       spyOn(authService, 'impersonate').and.callThrough();
-      eperson = EPersonMock;
+      eperson = EPersonMock2;
       component.epersonInitial = eperson;
       component.canDelete$ = observableOf(true);
       spyOn(component.epersonService, 'getActiveEPerson').and.returnValue(observableOf(eperson));
@@ -487,6 +531,59 @@ describe('EPersonFormComponent', () => {
       deleteButton.triggerEventHandler('click', null);
       fixture.detectChanges();
       expect(component.epersonService.deleteEPerson).toHaveBeenCalledWith(eperson);
+    });
+
+    it('should pass the combined warning label to the delete confirmation modal', () => {
+      const adminGroup = Object.assign(new Group(), { _name: 'Administrator' });
+      workspaceItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements: 1,
+        totalPages: 1,
+        currentPage: 1,
+      }), [{} as any])));
+      groupsDataService.findListByHref = jasmine.createSpy().and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements: 1,
+        totalPages: 1,
+        currentPage: 1,
+      }), [adminGroup])));
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(modalService.open).toHaveBeenCalled();
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
+        .toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    });
+
+    it('should show the friendly self-delete notification when the backend returns the self-delete error', () => {
+      spyOn(component.epersonService, 'deleteEPerson').and.returnValue(createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400));
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    });
+  });
+
+  describe('self delete button', () => {
+    beforeEach(() => {
+      component.epersonInitial = EPersonMock;
+      component.canDelete$ = observableOf(true);
+      spyOn(component.epersonService, 'getActiveEPerson').and.returnValue(observableOf(EPersonMock));
+      component.ngOnInit();
+      fixture.detectChanges();
+    });
+
+    it('should render the delete button as disabled for the current user', () => {
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).not.toBeNull();
+      expect(deleteButton.nativeElement.getAttribute('aria-disabled')).toBe('true');
+      expect(deleteButton.nativeElement.classList.contains('disabled')).toBeTrue();
     });
   });
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -499,6 +499,7 @@ describe('EPersonFormComponent', () => {
       modalService = (component as any).modalService;
       spyOn(modalService, 'open').and.returnValue(Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) }));
       component.ngOnInit();
+      component.currentAuthenticatedUserId = 'different-user-id';
       fixture.detectChanges();
     });
 
@@ -555,6 +556,56 @@ describe('EPersonFormComponent', () => {
       expect(modalService.open).toHaveBeenCalled();
       expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
         .toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    });
+
+    it('should detect administrator membership on later pages', () => {
+      const firstPage = createSuccessfulRemoteDataObject$(
+        buildPaginatedList(new PageInfo({
+          elementsPerPage: 100,
+          totalElements: 101,
+          totalPages: 2,
+          currentPage: 1,
+        }), [Object.assign(new Group(), { _name: 'Regular Group' })])
+      );
+      const secondPage = createSuccessfulRemoteDataObject$(
+        buildPaginatedList(new PageInfo({
+          elementsPerPage: 100,
+          totalElements: 101,
+          totalPages: 2,
+          currentPage: 2,
+        }), [Object.assign(new Group(), { _name: 'Administrator' })])
+      );
+
+      workspaceItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements: 0,
+        totalPages: 1,
+        currentPage: 1,
+      }), [])));
+      workflowItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements: 0,
+        totalPages: 1,
+        currentPage: 1,
+      }), [])));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(Object.assign(
+        new SearchObjects<DSpaceObject>(),
+        buildPaginatedList(new PageInfo({
+          elementsPerPage: 1,
+          totalElements: 0,
+          totalPages: 1,
+          currentPage: 1,
+        }), [])
+      )));
+      groupsDataService.findListByHref = jasmine.createSpy().and.returnValues(firstPage, secondPage);
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(groupsDataService.findListByHref).toHaveBeenCalledTimes(2);
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
+        .toBe('admin.access-control.epeople.delete.warning.admin');
     });
 
     it('should show the friendly self-delete notification when the backend returns the self-delete error', () => {

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -568,6 +568,24 @@ describe('EPersonFormComponent', () => {
       notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
       expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
     });
+
+    it('should hide enabled delete button before authenticated user id is resolved', () => {
+      component.currentAuthenticatedUserId = undefined;
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeNull();
+    });
+
+    it('should not open delete modal before authenticated user id is resolved', () => {
+      component.currentAuthenticatedUserId = undefined;
+      const deleteSpy = spyOn(component.epersonService, 'deleteEPerson').and.callThrough();
+
+      component.delete();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('self delete button', () => {

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -1,4 +1,6 @@
-import { Observable, of as observableOf } from 'rxjs';
+import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
+import { EPersonDeleteGuardService } from '../eperson-delete-guard.service';
 import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
@@ -10,7 +12,6 @@ import { buildPaginatedList, PaginatedList } from '../../../core/data/paginated-
 import { RemoteData } from '../../../core/data/remote-data';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
-import { Group } from '../../../core/eperson/models/group.model';
 import { PageInfo } from '../../../core/shared/page-info.model';
 import { FormBuilderService } from '../../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../../shared/notifications/notifications.service';
@@ -246,6 +247,7 @@ describe('EPersonFormComponent', () => {
         { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
         { provide: WorkflowItemDataService, useValue: workflowItemDataService },
         { provide: SearchService, useValue: searchService },
+        EPersonDeleteGuardService,
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring'])},
         { provide: EpersonRegistrationService, useValue: epersonRegistrationService },
         { provide: DSONameService, useValue: jasmine.createSpyObj('dsoNameService', {
@@ -535,77 +537,48 @@ describe('EPersonFormComponent', () => {
     });
 
     it('should pass the combined warning label to the delete confirmation modal', () => {
-      const adminGroup = Object.assign(new Group(), { _name: 'Administrator' });
       workspaceItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
         elementsPerPage: 1,
         totalElements: 1,
         totalPages: 1,
         currentPage: 1,
       }), [{} as any])));
-      groupsDataService.findListByHref = jasmine.createSpy().and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
-        elementsPerPage: 1,
-        totalElements: 1,
-        totalPages: 1,
-        currentPage: 1,
-      }), [adminGroup])));
+      // isAuthorized returns true by default -> the target is treated as an administrator
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, eperson.id);
+      expect(modalService.open).toHaveBeenCalled();
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
+        .toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    });
+
+    it('should detect administrator via the authorization feature', () => {
+      // all submitter probes empty (default), administrator feature -> true
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId === FeatureID.AdministratorOf));
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, eperson.id);
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
+        .toBe('admin.access-control.epeople.delete.warning.admin');
+    });
+
+    it('should still open the delete modal when a submitter probe errors (centralised catchError)', () => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      // workflow/search empty by default; AdministratorOf false so there is no warning to compose
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId !== FeatureID.AdministratorOf));
       fixture.detectChanges();
 
       const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
       deleteButton.triggerEventHandler('click', null);
 
       expect(modalService.open).toHaveBeenCalled();
-      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
-        .toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
-    });
-
-    it('should detect administrator membership on later pages', () => {
-      const firstPage = createSuccessfulRemoteDataObject$(
-        buildPaginatedList(new PageInfo({
-          elementsPerPage: 100,
-          totalElements: 101,
-          totalPages: 2,
-          currentPage: 1,
-        }), [Object.assign(new Group(), { _name: 'Regular Group' })])
-      );
-      const secondPage = createSuccessfulRemoteDataObject$(
-        buildPaginatedList(new PageInfo({
-          elementsPerPage: 100,
-          totalElements: 101,
-          totalPages: 2,
-          currentPage: 2,
-        }), [Object.assign(new Group(), { _name: 'Administrator' })])
-      );
-
-      workspaceItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
-        elementsPerPage: 1,
-        totalElements: 0,
-        totalPages: 1,
-        currentPage: 1,
-      }), [])));
-      workflowItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
-        elementsPerPage: 1,
-        totalElements: 0,
-        totalPages: 1,
-        currentPage: 1,
-      }), [])));
-      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(Object.assign(
-        new SearchObjects<DSpaceObject>(),
-        buildPaginatedList(new PageInfo({
-          elementsPerPage: 1,
-          totalElements: 0,
-          totalPages: 1,
-          currentPage: 1,
-        }), [])
-      )));
-      groupsDataService.findListByHref = jasmine.createSpy().and.returnValues(firstPage, secondPage);
-      fixture.detectChanges();
-
-      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
-      deleteButton.triggerEventHandler('click', null);
-
-      expect(groupsDataService.findListByHref).toHaveBeenCalledTimes(2);
-      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
-        .toBe('admin.access-control.epeople.delete.warning.admin');
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel).toBeUndefined();
     });
 
     it('should show the friendly self-delete notification when the backend returns the self-delete error', () => {

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -501,6 +501,10 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           return observableOf(null);
         }
 
+        if (!hasValue(this.currentAuthenticatedUserId)) {
+          return observableOf(null);
+        }
+
         if (this.isCurrentUser(eperson)) {
           this.showSelfDeleteNotification();
           return observableOf(null);

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -11,6 +11,7 @@ import { combineLatest as observableCombineLatest, Observable, of as observableO
 import { debounceTime, finalize, map, switchMap, take } from 'rxjs/operators';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
+import { RequestParam } from '../../../core/cache/models/request-param.model';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
@@ -29,6 +30,7 @@ import { AuthorizationDataService } from '../../../core/data/feature-authorizati
 import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { ConfirmationModalComponent } from '../../../shared/confirmation-modal/confirmation-modal.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { FindListOptions } from '../../../core/data/find-list-options.model';
 import { RequestService } from '../../../core/data/request.service';
 import { NoContent } from '../../../core/shared/NoContent.model';
 import { PaginationService } from '../../../core/pagination/pagination.service';
@@ -40,6 +42,12 @@ import { TYPE_REQUEST_FORGOT } from '../../../register-email-form/register-email
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { getEPersonsRoute } from '../../access-control-routing-paths';
+import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
+import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
+import { SearchService } from '../../../core/shared/search/search.service';
+import { PaginatedSearchOptions } from '../../../shared/search/models/paginated-search-options.model';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { SearchObjects } from '../../../shared/search/models/search-objects.model';
 
 @Component({
   selector: 'ds-eperson-form',
@@ -51,6 +59,9 @@ import { getEPersonsRoute } from '../../access-control-routing-paths';
 export class EPersonFormComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.form.';
+  selfDeleteWarningLabel = 'admin.access-control.epeople.notification.deleted.forbidden.self';
+
+  currentAuthenticatedUserId: string;
 
   /**
    * A unique id used for ds-form
@@ -198,6 +209,9 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     private authorizationService: AuthorizationDataService,
     private modalService: NgbModal,
     private paginationService: PaginationService,
+    private workspaceItemDataService: WorkspaceitemDataService,
+    private workflowItemDataService: WorkflowItemDataService,
+    private searchService: SearchService,
     public requestService: RequestService,
     private epersonRegistrationService: EpersonRegistrationService,
     public dsoNameService: DSONameService,
@@ -208,6 +222,9 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.activeEPerson$ = this.epersonService.getActiveEPerson();
+    this.subs.push(this.authService.getAuthenticatedUserFromStore().subscribe((currentUser: EPerson) => {
+      this.currentAuthenticatedUserId = currentUser?.id;
+    }));
     this.subs.push(this.activeEPerson$.subscribe((eperson: EPerson) => {
       this.epersonInitial = eperson;
       if (hasValue(eperson)) {
@@ -334,6 +351,12 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       switchMap((eperson) => this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(eperson) ? eperson.self : undefined))
     );
     this.canReset$ = observableOf(true);
+  }
+
+  private getDeleteAccess(): Observable<boolean> {
+    return this.activeEPerson$.pipe(
+      switchMap((eperson) => this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(eperson) ? eperson.self : undefined))
+    );
   }
 
   /**
@@ -474,40 +497,144 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     this.activeEPerson$.pipe(
       take(1),
       switchMap((eperson: EPerson) => {
-        const modalRef = this.modalService.open(ConfirmationModalComponent);
-        modalRef.componentInstance.dso = eperson;
-        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-        modalRef.componentInstance.brandColor = 'danger';
-        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+        if (!hasValue(eperson?.id)) {
+          return observableOf(null);
+        }
 
-        return modalRef.componentInstance.response.pipe(
+        if (this.isCurrentUser(eperson)) {
+          this.showSelfDeleteNotification();
+          return observableOf(null);
+        }
+
+        return this.getDeleteWarningLabel(eperson).pipe(
           take(1),
-          switchMap((confirm: boolean) => {
-            if (confirm && hasValue(eperson.id)) {
-              this.canDelete$ = observableOf(false);
-              return this.epersonService.deleteEPerson(eperson).pipe(
-                getFirstCompletedRemoteData(),
-                map((restResponse: RemoteData<NoContent>) => ({ restResponse, eperson }))
-              );
-            } else {
-              return observableOf(null);
-            }
-          }),
-          finalize(() => this.canDelete$ = observableOf(true))
+          switchMap((warningLabel: string | undefined) => {
+            const modalRef = this.modalService.open(ConfirmationModalComponent);
+            modalRef.componentInstance.dso = eperson;
+            modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+            modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+            modalRef.componentInstance.warningLabel = warningLabel;
+            modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+            modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+            modalRef.componentInstance.brandColor = 'danger';
+            modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+
+            return modalRef.componentInstance.response.pipe(
+              take(1),
+              switchMap((confirm: boolean) => {
+                if (confirm) {
+                  this.canDelete$ = observableOf(false);
+                  return this.epersonService.deleteEPerson(eperson).pipe(
+                    getFirstCompletedRemoteData(),
+                    map((restResponse: RemoteData<NoContent>) => ({ restResponse, eperson, attempted: true }))
+                  );
+                }
+
+                return observableOf({ restResponse: null, eperson, attempted: false });
+              }),
+              finalize(() => this.canDelete$ = this.getDeleteAccess())
+            );
+          })
         );
       })
-    ).subscribe(({ restResponse, eperson }: { restResponse: RemoteData<NoContent> | null, eperson: EPerson }) => {
+    ).subscribe((result: { restResponse: RemoteData<NoContent> | null, eperson: EPerson, attempted: boolean } | null) => {
+      if (!result?.attempted) {
+        return;
+      }
+
+      const { restResponse, eperson } = result;
       if (restResponse?.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
         void this.router.navigate([getEPersonsRoute()]);
+      } else if (this.isSelfDeletionError(restResponse)) {
+        this.showSelfDeleteNotification();
       } else {
-        this.notificationsService.error(`Error occurred when trying to delete EPerson with id: ${eperson?.id} with code: ${restResponse?.statusCode} and message: ${restResponse?.errorMessage}`);
+        this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
+          name: this.dsoNameService.getName(eperson),
+          id: eperson?.id,
+          statusCode: restResponse?.statusCode,
+          errorMessage: restResponse?.errorMessage,
+          restResponse,
+        }));
       }
       this.cancelForm.emit();
     });
+  }
+
+  isCurrentUser(ePerson: EPerson): boolean {
+    return hasValue(ePerson?.id) && ePerson.id === this.currentAuthenticatedUserId;
+  }
+
+  private getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
+    return observableCombineLatest([
+      this.hasSubmittedItems(ePerson.id),
+      this.isAdministrator(ePerson),
+    ]).pipe(
+      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
+        if (hasSubmittedItems && isAdmin) {
+          return 'admin.access-control.epeople.delete.warning.submitterAndAdmin';
+        }
+        if (hasSubmittedItems) {
+          return 'admin.access-control.epeople.delete.warning.submitter';
+        }
+        if (isAdmin) {
+          return 'admin.access-control.epeople.delete.warning.admin';
+        }
+        return undefined;
+      })
+    );
+  }
+
+  private hasSubmittedItems(epersonId: string): Observable<boolean> {
+    const submitterSearchOptions = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 1,
+      searchParams: [new RequestParam('uuid', epersonId)],
+    });
+    const archivedSearchOptions = new PaginatedSearchOptions({
+      query: `submitter_authority:${epersonId}`,
+      pagination: Object.assign(new PaginationComponentOptions(), {
+        currentPage: 1,
+        pageSize: 1,
+      }),
+    });
+
+    return observableCombineLatest([
+      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+      ),
+      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+      ),
+      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+      ),
+    ]).pipe(
+      map((results: boolean[]) => results.some(Boolean))
+    );
+  }
+
+  private isAdministrator(ePerson: EPerson): Observable<boolean> {
+    const options = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 100,
+    });
+
+    return this.groupsDataService.findListByHref(ePerson._links.groups.href, options).pipe(
+      getFirstCompletedRemoteData(),
+      map((rd: RemoteData<PaginatedList<Group>>) => rd.hasSucceeded && rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator')),
+    );
+  }
+
+  private isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
+    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
+  }
+
+  private showSelfDeleteNotification(): void {
+    this.notificationsService.error(this.translateService.get(this.selfDeleteWarningLabel));
   }
 
   /**

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -627,9 +627,34 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       elementsPerPage: 100,
     });
 
-    return this.groupsDataService.findListByHref(ePerson._links.groups.href, options).pipe(
+    return this.hasAdministratorGroupOnPage(ePerson._links.groups.href, options);
+  }
+
+  private hasAdministratorGroupOnPage(groupsHref: string, options: FindListOptions): Observable<boolean> {
+    return this.groupsDataService.findListByHref(groupsHref, options).pipe(
       getFirstCompletedRemoteData(),
-      map((rd: RemoteData<PaginatedList<Group>>) => rd.hasSucceeded && rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator')),
+      switchMap((rd: RemoteData<PaginatedList<Group>>) => {
+        if (!rd.hasSucceeded || !hasValue(rd.payload) || !hasValue(rd.payload.pageInfo)) {
+          return observableOf(false);
+        }
+
+        const hasAdministratorGroup = rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator');
+        if (hasAdministratorGroup) {
+          return observableOf(true);
+        }
+
+        const currentPage = rd.payload.pageInfo.currentPage;
+        const totalPages = rd.payload.pageInfo.totalPages;
+        const hasMorePages = hasValue(currentPage) && hasValue(totalPages) && currentPage < totalPages;
+        if (!hasMorePages) {
+          return observableOf(false);
+        }
+
+        const nextPageOptions = Object.assign(new FindListOptions(), options, {
+          currentPage: currentPage + 1,
+        });
+        return this.hasAdministratorGroupOnPage(groupsHref, nextPageOptions);
+      }),
     );
   }
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -11,7 +11,6 @@ import { combineLatest as observableCombineLatest, Observable, of as observableO
 import { debounceTime, finalize, map, switchMap, take } from 'rxjs/operators';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
-import { RequestParam } from '../../../core/cache/models/request-param.model';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
 import { EPerson } from '../../../core/eperson/models/eperson.model';
@@ -30,7 +29,6 @@ import { AuthorizationDataService } from '../../../core/data/feature-authorizati
 import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { ConfirmationModalComponent } from '../../../shared/confirmation-modal/confirmation-modal.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { FindListOptions } from '../../../core/data/find-list-options.model';
 import { RequestService } from '../../../core/data/request.service';
 import { NoContent } from '../../../core/shared/NoContent.model';
 import { PaginationService } from '../../../core/pagination/pagination.service';
@@ -42,12 +40,7 @@ import { TYPE_REQUEST_FORGOT } from '../../../register-email-form/register-email
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { getEPersonsRoute } from '../../access-control-routing-paths';
-import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
-import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
-import { SearchService } from '../../../core/shared/search/search.service';
-import { PaginatedSearchOptions } from '../../../shared/search/models/paginated-search-options.model';
-import { DSpaceObject } from '../../../core/shared/dspace-object.model';
-import { SearchObjects } from '../../../shared/search/models/search-objects.model';
+import { EPersonDeleteGuardService, SELF_DELETE_WARNING_LABEL } from '../eperson-delete-guard.service';
 
 @Component({
   selector: 'ds-eperson-form',
@@ -59,7 +52,7 @@ import { SearchObjects } from '../../../shared/search/models/search-objects.mode
 export class EPersonFormComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.form.';
-  selfDeleteWarningLabel = 'admin.access-control.epeople.notification.deleted.forbidden.self';
+  selfDeleteWarningLabel = SELF_DELETE_WARNING_LABEL;
 
   currentAuthenticatedUserId: string;
 
@@ -209,9 +202,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     private authorizationService: AuthorizationDataService,
     private modalService: NgbModal,
     private paginationService: PaginationService,
-    private workspaceItemDataService: WorkspaceitemDataService,
-    private workflowItemDataService: WorkflowItemDataService,
-    private searchService: SearchService,
+    private deleteGuard: EPersonDeleteGuardService,
     public requestService: RequestService,
     private epersonRegistrationService: EpersonRegistrationService,
     public dsoNameService: DSONameService,
@@ -506,11 +497,11 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
         }
 
         if (this.isCurrentUser(eperson)) {
-          this.showSelfDeleteNotification();
+          this.deleteGuard.showSelfDeleteNotification();
           return observableOf(null);
         }
 
-        return this.getDeleteWarningLabel(eperson).pipe(
+        return this.deleteGuard.getDeleteWarningLabel(eperson).pipe(
           take(1),
           switchMap((warningLabel: string | undefined) => {
             const modalRef = this.modalService.open(ConfirmationModalComponent);
@@ -550,8 +541,8 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       if (restResponse?.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
         void this.router.navigate([getEPersonsRoute()]);
-      } else if (this.isSelfDeletionError(restResponse)) {
-        this.showSelfDeleteNotification();
+      } else if (this.deleteGuard.isSelfDeletionError(restResponse)) {
+        this.deleteGuard.showSelfDeleteNotification();
       } else {
         this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
           name: this.dsoNameService.getName(eperson),
@@ -566,104 +557,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   }
 
   isCurrentUser(ePerson: EPerson): boolean {
-    return hasValue(ePerson?.id) && ePerson.id === this.currentAuthenticatedUserId;
-  }
-
-  private getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
-    return observableCombineLatest([
-      this.hasSubmittedItems(ePerson.id),
-      this.isAdministrator(ePerson),
-    ]).pipe(
-      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
-        if (hasSubmittedItems && isAdmin) {
-          return 'admin.access-control.epeople.delete.warning.submitterAndAdmin';
-        }
-        if (hasSubmittedItems) {
-          return 'admin.access-control.epeople.delete.warning.submitter';
-        }
-        if (isAdmin) {
-          return 'admin.access-control.epeople.delete.warning.admin';
-        }
-        return undefined;
-      })
-    );
-  }
-
-  private hasSubmittedItems(epersonId: string): Observable<boolean> {
-    const submitterSearchOptions = Object.assign(new FindListOptions(), {
-      currentPage: 1,
-      elementsPerPage: 1,
-      searchParams: [new RequestParam('uuid', epersonId)],
-    });
-    const archivedSearchOptions = new PaginatedSearchOptions({
-      query: `submitter_authority:${epersonId}`,
-      pagination: Object.assign(new PaginationComponentOptions(), {
-        currentPage: 1,
-        pageSize: 1,
-      }),
-    });
-
-    return observableCombineLatest([
-      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
-      ),
-      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
-      ),
-      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
-        getFirstCompletedRemoteData(),
-        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
-      ),
-    ]).pipe(
-      map((results: boolean[]) => results.some(Boolean))
-    );
-  }
-
-  private isAdministrator(ePerson: EPerson): Observable<boolean> {
-    const options = Object.assign(new FindListOptions(), {
-      currentPage: 1,
-      elementsPerPage: 100,
-    });
-
-    return this.hasAdministratorGroupOnPage(ePerson._links.groups.href, options);
-  }
-
-  private hasAdministratorGroupOnPage(groupsHref: string, options: FindListOptions): Observable<boolean> {
-    return this.groupsDataService.findListByHref(groupsHref, options).pipe(
-      getFirstCompletedRemoteData(),
-      switchMap((rd: RemoteData<PaginatedList<Group>>) => {
-        if (!rd.hasSucceeded || !hasValue(rd.payload) || !hasValue(rd.payload.pageInfo)) {
-          return observableOf(false);
-        }
-
-        const hasAdministratorGroup = rd.payload.page.some((group: Group) => group.name?.toLowerCase() === 'administrator');
-        if (hasAdministratorGroup) {
-          return observableOf(true);
-        }
-
-        const currentPage = rd.payload.pageInfo.currentPage;
-        const totalPages = rd.payload.pageInfo.totalPages;
-        const hasMorePages = hasValue(currentPage) && hasValue(totalPages) && currentPage < totalPages;
-        if (!hasMorePages) {
-          return observableOf(false);
-        }
-
-        const nextPageOptions = Object.assign(new FindListOptions(), options, {
-          currentPage: currentPage + 1,
-        });
-        return this.hasAdministratorGroupOnPage(groupsHref, nextPageOptions);
-      }),
-    );
-  }
-
-  private isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
-    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
-  }
-
-  private showSelfDeleteNotification(): void {
-    this.notificationsService.error(this.translateService.get(this.selfDeleteWarningLabel));
+    return this.deleteGuard.isCurrentUser(ePerson, this.currentAuthenticatedUserId);
   }
 
   /**

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -344,12 +344,6 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     this.canReset$ = observableOf(true);
   }
 
-  private getDeleteAccess(): Observable<boolean> {
-    return this.activeEPerson$.pipe(
-      switchMap((eperson) => this.authorizationService.isAuthorized(FeatureID.CanDelete, hasValue(eperson) ? eperson.self : undefined))
-    );
-  }
-
   /**
    * Stop editing the currently selected eperson
    */
@@ -527,7 +521,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
 
                 return observableOf({ restResponse: null, eperson, attempted: false });
               }),
-              finalize(() => this.canDelete$ = this.getDeleteAccess())
+              finalize(() => this.canDelete$ = observableOf(true))
             );
           })
         );

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.html
@@ -6,6 +6,7 @@
   </div>
   <div class="modal-body">
     <p>{{ infoLabel | translate:{ dsoName: dsoNameService.getName(dso) } }}</p>
+    <p *ngIf="warningLabel" class="text-warning mb-0">{{ warningLabel | translate:{ dsoName: dsoNameService.getName(dso) } }}</p>
   </div>
   <div class="modal-footer">
     <button type="button" class="cancel btn btn-outline-secondary" (click)="cancelPressed()" aria-label="Cancel">

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.spec.ts
@@ -35,6 +35,19 @@ describe('ConfirmationModalComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should not render a warning message by default', () => {
+    expect(debugElement.query(By.css('.modal-body .text-warning'))).toBeNull();
+  });
+
+  it('should render the warning message when warningLabel is set', () => {
+    component.warningLabel = 'confirmation-modal.warning';
+    fixture.detectChanges();
+
+    const warningMessage = debugElement.query(By.css('.modal-body .text-warning'));
+    expect(warningMessage).not.toBeNull();
+    expect(warningMessage.nativeElement.textContent).toContain('confirmation-modal.warning');
+  });
+
   describe('close', () => {
     beforeEach(() => {
       component.close();

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.ts
@@ -10,6 +10,7 @@ import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 export class ConfirmationModalComponent {
   @Input() headerLabel: string;
   @Input() infoLabel: string;
+  @Input() warningLabel?: string;
   @Input() cancelLabel: string;
   @Input() confirmLabel: string;
   @Input() confirmIcon: string;

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -557,11 +557,11 @@
   // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
   "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
 
-  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user is a member of the Administrator group. Deleting this EPerson will remove an administrator account.",
-  "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel je členem skupiny Správce. Smazání tohoto uživatele odebere účet správce.",
+  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel má oprávnění správce. Smazání tohoto uživatele odebere účet správce.",
 
-  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and is a member of the Administrator group. Deleting this EPerson may affect submission ownership and remove an administrator account.",
-  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Upozornění: Tento uživatel odeslal položky a je členem skupiny Správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
+  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Upozornění: Tento uživatel odeslal položky a má oprávnění správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
 
   // "admin.access-control.groups.title": "Groups",
   "admin.access-control.groups.title": "Skupiny",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -551,6 +551,18 @@
   // "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
   "admin.access-control.epeople.notification.deleted.success": "Úspěšně odstraněn uživatel: \"{{name}}\"",
 
+  // "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
+  "admin.access-control.epeople.notification.deleted.forbidden.self": "Nemůžete smazat svůj vlastní účet uživatele.",
+
+  // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
+  "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repositáři.",
+
+  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user is a member of the Administrator group. Deleting this EPerson will remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel je členem skupiny Správce. Smazání tohoto uživatele odebere účet správce.",
+
+  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and is a member of the Administrator group. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Upozornění: Tento uživatel odeslal položky a je členem skupiny Správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
+
   // "admin.access-control.groups.title": "Groups",
   "admin.access-control.groups.title": "Skupiny",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -555,7 +555,7 @@
   "admin.access-control.epeople.notification.deleted.forbidden.self": "Nemůžete smazat svůj vlastní účet uživatele.",
 
   // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
-  "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repositáři.",
+  "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
 
   // "admin.access-control.epeople.delete.warning.admin": "Warning: this user is a member of the Administrator group. Deleting this EPerson will remove an administrator account.",
   "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel je členem skupiny Správce. Smazání tohoto uživatele odebere účet správce.",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -351,6 +351,14 @@
 
   "admin.access-control.epeople.form.notification.deleted.failure": "Failed to delete EPerson \"{{name}}\"",
 
+  "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
+
+  "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
+
+  "admin.access-control.epeople.delete.warning.admin": "Warning: this user is a member of the Administrator group. Deleting this EPerson will remove an administrator account.",
+
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and is a member of the Administrator group. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+
   "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
 
   "admin.access-control.epeople.form.table.id": "ID",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -355,9 +355,9 @@
 
   "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
 
-  "admin.access-control.epeople.delete.warning.admin": "Warning: this user is a member of the Administrator group. Deleting this EPerson will remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
 
-  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and is a member of the Administrator group. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
 
   "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
 


### PR DESCRIPTION
## Problem description

The EPeople administration UI did not adequately guard the delete flow for high-risk cases. This PR adds better handling for self-deletion and surfaces contextual warnings when deleting users with elevated impact.

## Analysis

This PR:
- prevents deleting the currently authenticated user from the EPeople registry and EPerson form UI
- shows a clear self-delete warning message instead of allowing the action to proceed
- adds contextual warnings in the confirmation modal when the target user is an administrator, has submitted items, or both
- adds the related English and Czech translation messages
- updates unit tests for the new delete-button, warning, and notification behavior

### Copilot review
- [x] Requested review from Copilot