### PR TITLE
resolve archived item hang and false Archived badge in MyDSpace

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ import {
 import {
   NavigationCancel,
   NavigationEnd,
+  NavigationError,
   NavigationStart,
   Router,
 } from '@angular/router';
@@ -122,7 +123,8 @@ export class AppComponent implements OnInit, AfterViewInit {
         distinctNext(this.isRouteLoading$, true);
       } else if (
         event instanceof NavigationEnd ||
-        event instanceof NavigationCancel
+        event instanceof NavigationCancel ||
+        event instanceof NavigationError
       ) {
         distinctNext(this.isRouteLoading$, false);
       }

--- a/src/app/core/submission/resolver/submission-links-to-follow.ts
+++ b/src/app/core/submission/resolver/submission-links-to-follow.ts
@@ -14,7 +14,6 @@ export const SUBMISSION_LINKS_TO_FOLLOW: FollowLinkConfig<WorkflowItem | Workspa
       followLink('parentCommunity', {},
         followLink('parentCommunity')),
     ),
-    followLink('relationships'),
     followLink('version', {}, followLink('versionhistory')),
     followLink('thumbnail'),
   ),

--- a/src/app/core/submission/resolver/submission-links-to-follow.ts
+++ b/src/app/core/submission/resolver/submission-links-to-follow.ts
@@ -9,6 +9,14 @@ import { WorkspaceItem } from '../models/workspaceitem.model';
  * Needs to be in a separate file to prevent circular dependencies in webpack.
  */
 export const SUBMISSION_LINKS_TO_FOLLOW: FollowLinkConfig<WorkflowItem | WorkspaceItem>[] = [
-  followLink('item'),
+  followLink('item', {},
+    followLink('owningCollection', {},
+      followLink('parentCommunity', {},
+        followLink('parentCommunity')),
+    ),
+    followLink('relationships'),
+    followLink('version', {}, followLink('versionhistory')),
+    followLink('thumbnail'),
+  ),
   followLink('collection'),
 ];

--- a/src/app/core/submission/resolver/submission-object.resolver.ts
+++ b/src/app/core/submission/resolver/submission-object.resolver.ts
@@ -26,7 +26,7 @@ export class SubmissionObjectResolver<T> implements Resolve<RemoteData<T>> {
      */
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<RemoteData<T>> {
         const itemRD$ = this.dataService.findById(route.params.id,
-            true,
+            false,
             false,
             ...SUBMISSION_LINKS_TO_FOLLOW,
         ).pipe(

--- a/src/app/item-page/item.resolver.ts
+++ b/src/app/item-page/item.resolver.ts
@@ -51,7 +51,7 @@ export class ItemResolver implements Resolve<RemoteData<Item>> {
    */
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<RemoteData<Item>> {
     const itemRD$ = this.itemService.findById(route.params.id,
-      true,
+      false,
       true,
       ...getItemPageLinksToFollow(),
     ).pipe(

--- a/src/app/item-page/versions/notice/item-versions-notice.component.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.ts
@@ -89,8 +89,6 @@ export class ItemVersionsNoticeComponent implements OnInit {
         map((isLatest) => isLatest != null && !isLatest),
         startWith(false),
       );
-    }
-
     // Compute the destination URL from latestVersion$ with the namespace
     this.destinationUrl$ = this.latestVersion$.pipe(
       switchMap(latestVersion => latestVersion?.item || of(null)),
@@ -110,7 +108,11 @@ export class ItemVersionsNoticeComponent implements OnInit {
 
         return finalUrl;
       })
-    );
+      );
+    } else {
+      this.showLatestVersionNotice$ = of(false);
+      this.destinationUrl$ = of(this.document.location.pathname);
+    }
   }
 
 }

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-search-result/item-search-result-list-element-submission.component.spec.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-search-result/item-search-result-list-element-submission.component.spec.ts
@@ -78,6 +78,13 @@ describe('ItemMyDSpaceResultListElementComponent', () => {
   });
 
   it('should have correct badge context', () => {
+    expect(component.badgeContext).toEqual(Context.Any);
+  });
+
+  it('should show archived badge context when item is archived', () => {
+    component.dso = Object.assign(new Item(), mockResultObject.indexableObject, { isArchived: true });
+    component.ngOnInit();
+
     expect(component.badgeContext).toEqual(Context.MyDSpaceArchived);
   });
 

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-search-result/item-search-result-list-element-submission.component.ts
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-search-result/item-search-result-list-element-submission.component.ts
@@ -22,7 +22,7 @@ export class ItemSearchResultListElementSubmissionComponent extends SearchResult
   /**
    * Represents the badge context
    */
-  public badgeContext = Context.MyDSpaceArchived;
+  public badgeContext = Context.Any;
 
 
   /**
@@ -33,6 +33,14 @@ export class ItemSearchResultListElementSubmissionComponent extends SearchResult
 
   ngOnInit() {
     super.ngOnInit();
+
+    // Show the Archived badge only for items that are actually archived.
+    if (this.dso?.isArchived) {
+      this.badgeContext = Context.MyDSpaceArchived;
+    } else {
+      this.badgeContext = Context.Any;
+    }
+
     this.showThumbnails = this.appConfig.browseBy.showThumbnails;
   }
 }

--- a/src/app/shared/theme-support/themed.component.ts
+++ b/src/app/shared/theme-support/themed.component.ts
@@ -119,6 +119,9 @@ export abstract class ThemedComponent<T> implements AfterViewInit, OnDestroy, On
 
     this.lazyLoadSub = this.lazyLoadObs.subscribe(([simpleChanges, constructor]: [SimpleChanges, GenericConstructor<T>]) => {
       this.destroyComponentInstance();
+      if (!this.vcr || !this.themedElementContent) {
+        return;
+      }
       this.compRef = this.vcr.createComponent(constructor, {
         projectableNodes: [this.themedElementContent.nativeElement.childNodes],
       });

--- a/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts
@@ -93,7 +93,7 @@ describe('ViewTrackerResolverService', () => {
     expect(emittedEvent.properties.dc_identifier).toBeUndefined();
   });
 
-  it('should handle missing dso gracefully (dc_identifier undefined)', () => {
+  it('should not emit tracking event when dso is missing', () => {
     const routeSnapshot = {
       data: {
         dso: {
@@ -111,9 +111,7 @@ describe('ViewTrackerResolverService', () => {
     service.resolve(routeSnapshot, stateSnapshot);
     routerEvents$.next(new ResolveEnd(1, '/', '/', {} as any));
 
-    expect(emittedEvent).toBeDefined();
-    expect(emittedEvent.action).toBe('page_view');
-    expect(emittedEvent.properties.dc_identifier).toBeUndefined();
+    expect(emittedEvent).toBeUndefined();
   });
 
   it('should use custom dsoPath from route data when provided', () => {

--- a/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts
@@ -25,6 +25,7 @@ export class ViewTrackerResolverService {
     const dsoPath = routeSnapshot.data.dsoPath || 'dso.payload'; // Fetch the resolvers passed via the route data
     this.router.events.pipe(
       filter(event => event instanceof ResolveEnd),
+      filter(() => !!this.getNestedProperty(routeSnapshot.data, dsoPath)),
       take(1),
       switchMap(() =>
         this.referrerService.getReferrer().pipe(take(1))))

--- a/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, } from '@angular/core';
 import { Angulartics2 } from 'angulartics2';
-import { switchMap } from 'rxjs';
+import { EMPTY, map, switchMap } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 
 import { ReferrerService } from '../../../core/services/referrer.service';
@@ -25,12 +25,18 @@ export class ViewTrackerResolverService {
     const dsoPath = routeSnapshot.data.dsoPath || 'dso.payload'; // Fetch the resolvers passed via the route data
     this.router.events.pipe(
       filter(event => event instanceof ResolveEnd),
-      filter(() => !!this.getNestedProperty(routeSnapshot.data, dsoPath)),
       take(1),
-      switchMap(() =>
-        this.referrerService.getReferrer().pipe(take(1))))
-      .subscribe((referrer: string) => {
+      switchMap(() => {
         const object = this.getNestedProperty(routeSnapshot.data, dsoPath);
+        if (!object) {
+          return EMPTY;
+        }
+        return this.referrerService.getReferrer().pipe(
+          take(1),
+          map((referrer: string) => ({ object, referrer })),
+        );
+      }))
+      .subscribe(({ object, referrer }: { object: any, referrer: string }) => {
         const dc_identifier = object?.firstMetadataValue?.('dc.identifier.uri');
         this.angulartics2.eventTrack.next({
           action: 'page_view',


### PR DESCRIPTION
## Problem description

This PR addresses two MyDSpace issues:

1. **Archived item view could hang with endless loading** after a workspace-to-archived navigation sequence (first archived visit works, workspace visit works, second archived visit hangs).
2. **MyDSpace submission/workspace rows could show an incorrect "Archived" badge** for non-archived items.

### Console errors resolved

- `Cannot read properties of undefined (reading 'pipe')` in `ItemVersionsNoticeComponent`
- `Cannot read properties of undefined (reading 'createComponent')` in `ThemedComponent`
- `Cannot read properties of undefined (reading 'uuid')` in `StatisticsService`

## Analysis

Root cause was a multi-part resolver/cache/lifecycle interaction:

1. Workspace-linked and archived routes resolved the same item via different resolver paths with inconsistent fetch/link strategies.
2. Cache-first behaviour plus narrower workspace-linked embeds could surface partial item data where version-dependent code expected full links.
3. Missing defensive guards in `ItemVersionsNoticeComponent` and `ThemedComponent` caused runtime exceptions in these edge flows.
4. Global route loading state did not clear on `NavigationError`.
5. View tracking attempted emission when resolved object data was absent.
6. Archived badge in submission list element was context-hardcoded rather than driven by the actual `item.isArchived` flag.

## Changes

| File | Change |
|------|--------|
| `src/app/app.component.ts` | Added `NavigationError` handling to route loader reset |
| `src/app/core/submission/resolver/submission-links-to-follow.ts` | Expanded submission item embeds to match item-page expectations (`version`, `versionhistory`, `relationships`, `owningCollection`, `thumbnail`) |
| `src/app/core/submission/resolver/submission-object.resolver.ts` | Changed `useCachedVersionIfAvailable` to `false` |
| `src/app/item-page/item.resolver.ts` | Changed `useCachedVersionIfAvailable` to `false` |
| `src/app/item-page/versions/notice/item-versions-notice.component.ts` | Added safe fallback when `item.version` is absent |
| `src/app/shared/theme-support/themed.component.ts` | Added guard before `createComponent` when `vcr` or `themedElementContent` is missing |
| `src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts` | Added filter to prevent tracking emission when DSO is missing |
| `src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts` | Updated test to match new tracking contract |
| `src/app/shared/object-list/.../item-search-result-list-element-submission.component.ts` | Check `item.isArchived` before showing "Archived" badge |
| `src/app/shared/object-list/.../item-search-result-list-element-submission.component.spec.ts` | Updated tests for corrected badge logic |

### Copilot review

- [x] Requested review from Copilot