### PR TITLE
[Backport dtq-dev] 141 lost license in workflow edit

### DIFF
--- a/src/app/submission/sections/clarin-license-resource/section-license.component.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.ts
@@ -16,10 +16,9 @@ import { Operation } from 'fast-json-patch';
 import { ClarinLicenseDataService } from '../../../core/data/clarin/clarin-license-data.service';
 import { ClarinLicense } from '../../../core/shared/clarin/clarin-license.model';
 import { getFirstCompletedRemoteData, getFirstSucceededRemoteListPayload } from '../../../core/shared/operators';
-import { distinctUntilChanged, filter, find } from 'rxjs/operators';
-import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
+import { distinctUntilChanged, filter } from 'rxjs/operators';
 import { RemoteDataBuildService } from '../../../core/cache/builders/remote-data-build.service';
-import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
+import { SubmissionService } from '../../submission.service';
 import { RemoteData } from '../../../core/data/remote-data';
 import parseSectionErrors from '../../utils/parseSectionErrors';
 import { normalizeSectionData } from '../../../core/submission/submission-response-parsing.service';
@@ -27,7 +26,7 @@ import { License4Selector } from './license-4-selector.model';
 import { ConfigurationProperty } from '../../../core/shared/configuration-property.model';
 import { HELP_DESK_PROPERTY } from '../../../item-page/tombstone/tombstone.component';
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
-import { WorkspaceItem } from '../../../core/submission/models/workspaceitem.model';
+import { SubmissionObject } from '../../../core/submission/models/submission-object.model';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { ItemDataService } from '../../../core/data/item-data.service';
 import { Item } from '../../../core/shared/item.model';
@@ -134,8 +133,7 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
    * @param clarinLicenseService
    * @param translateService
    * @param itemService
-   * @param workspaceItemService
-   * @param halService
+   * @param submissionService
    * @param rdbService
    * @param configurationDataService
    * @param requestService
@@ -150,8 +148,7 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
               protected clarinLicenseService: ClarinLicenseDataService,
               protected translateService: TranslateService,
               protected itemService: ItemDataService,
-              protected workspaceItemService: WorkspaceitemDataService,
-              protected halService: HALEndpointService,
+              protected submissionService: SubmissionService,
               protected rdbService: RemoteDataBuildService,
               private configurationDataService: ConfigurationDataService,
               protected requestService: RequestService,
@@ -195,11 +192,17 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
     this.formId = this.formService.getUniqueId(this.sectionData.id);
 
     // Load the accepted license of the item
-    this.getActualWorkspaceItem()
-      .then((workspaceItemRD: RemoteData<WorkspaceItem>) => {
-        this.itemService.findByHref(workspaceItemRD.payload._links.item.href)
+    this.getActualSubmissionItem()
+      .then((submissionItemRD: RemoteData<SubmissionObject>) => {
+        if (!submissionItemRD?.hasSucceeded || !submissionItemRD.payload?._links?.item?.href) {
+          return;
+        }
+        this.itemService.findByHref(submissionItemRD.payload._links.item.href)
           .pipe(getFirstCompletedRemoteData())
           .subscribe((itemRD: RemoteData<Item>) => {
+            if (!itemRD?.hasSucceeded || !itemRD.payload) {
+              return;
+            }
             // Load the metadata where is store clarin license name (`dc.rights`).
             const item = itemRD.payload;
             const dcRightsMetadata = item.metadata['dc.rights'];
@@ -272,26 +275,22 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
     }
 
     this.updateSectionStatus();
-    await this.getActualWorkspaceItem()
-      .then(workspaceItemRD => {
+    await this.getActualSubmissionItem()
+      .then(submissionItemRD => {
+        if (!submissionItemRD?.hasSucceeded || !submissionItemRD.payload?._links?.self?.href) {
+          return;
+        }
         const requestId = this.requestService.generateRequestId();
-        const hrefObs = this.halService.getEndpoint(this.workspaceItemService.getLinkPath());
-
         const patchOperation2 = {
           op: 'replace', path: '/license', value: licenseNameRest
         } as Operation;
-
-        hrefObs.pipe(
-          find((href: string) => hasValue(href)),
-        ).subscribe((href: string) => {
-          const request = new PatchRequest(requestId, href + '/' + workspaceItemRD.payload.id, [patchOperation2]);
-          this.requestService.send(request);
-        });
+        const request = new PatchRequest(requestId, submissionItemRD.payload._links.self.href, [patchOperation2]);
+        this.requestService.send(request);
 
         // process the response
         this.rdbService.buildFromRequestUUID(requestId)
           .pipe(getFirstCompletedRemoteData())
-          .subscribe((response: RemoteData<WorkspaceItem>) => {
+          .subscribe((response: RemoteData<SubmissionObject>) => {
 
             // show validation errors in every section
             const workspaceitem = response.payload;
@@ -463,10 +462,11 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
   }
 
   /**
-   * Get the current workspace item by the submissionId.
+   * Get the current submission item (workspace or workflow) by the submissionId.
+   * This method is route-aware and retrieves from the appropriate endpoint based on the current URL.
    */
-  private async getActualWorkspaceItem(): Promise<RemoteData<WorkspaceItem>> {
-    return this.workspaceItemService.findById(this.submissionId)
+  private async getActualSubmissionItem(): Promise<RemoteData<SubmissionObject>> {
+    return this.submissionService.retrieveSubmission(this.submissionId)
       .pipe(getFirstCompletedRemoteData()).toPromise();
   }
 


### PR DESCRIPTION
Backport of #144 to `dtq-dev`.

The automated backport (port-pr) reported a failed cherry-pick of `fb97ec9f16`. Re-applied manually with `git cherry-pick -x`, which resolved cleanly via 3-way auto-merge on `section-license.component.ts`. The resulting patch is content-identical to the original commit (only hunk-header line numbers differ, by a 1-line offset in `dtq-dev`); no merge markers, same single-file scope (26/26).

npm/build is not available locally in this environment, so verification was by patch-equivalence to the already-merged, reviewed #144 — CI lints/builds this branch.