### PR TITLE
Handle token refresh and prevent duplicate extends

### DIFF
--- a/src/app/shared/idle-modal/idle-modal.component.spec.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.spec.ts
@@ -2,11 +2,13 @@ import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
+import { of as observableOf, Subject, throwError } from 'rxjs';
 import { IdleModalComponent } from './idle-modal.component';
 import { AuthService } from '../../core/auth/auth.service';
 import { By } from '@angular/platform-browser';
 import { Store } from '@ngrx/store';
 import { LogOutAction } from '../../core/auth/auth.actions';
+import { AuthTokenInfo } from '../../core/auth/models/auth-token-info.model';
 
 describe('IdleModalComponent', () => {
   let component: IdleModalComponent;
@@ -19,7 +21,10 @@ describe('IdleModalComponent', () => {
 
   beforeEach(waitForAsync(() => {
     modalStub = jasmine.createSpyObj('modalStub', ['close']);
-    authServiceStub = jasmine.createSpyObj('authService', ['setIdle']);
+    authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'getToken', 'refreshAuthenticationToken', 'replaceToken']);
+    const token = new AuthTokenInfo('test-token');
+    authServiceStub.getToken.and.returnValue(token);
+    authServiceStub.refreshAuthenticationToken.and.returnValue(observableOf(token));
     storeStub = jasmine.createSpyObj('store', ['dispatch']);
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -57,6 +62,59 @@ describe('IdleModalComponent', () => {
     });
     it('response \'closed\' should emit true', () => {
       expect(component.response.emit).toHaveBeenCalledWith(true);
+    });
+
+    it('should refresh authentication token with current token', () => {
+      expect(authServiceStub.refreshAuthenticationToken).toHaveBeenCalledWith(authServiceStub.getToken.calls.mostRecent().returnValue);
+    });
+
+    it('should replace token before closing modal', () => {
+      const replaceTokenOrder = authServiceStub.replaceToken.calls.first().invocationOrder;
+      const closeOrder = modalStub.close.calls.first().invocationOrder;
+      expect(replaceTokenOrder).toBeLessThan(closeOrder);
+    });
+  });
+
+  describe('extendSessionAndCloseModal hardening', () => {
+    it('should dispatch LogOutAction and close modal when refresh fails', () => {
+      authServiceStub.refreshAuthenticationToken.and.returnValue(throwError(() => new Error('refresh failed')));
+      spyOn(component, 'closeModal').and.callThrough();
+
+      component.extendSessionAndCloseModal();
+
+      expect(storeStub.dispatch).toHaveBeenCalledWith(new LogOutAction());
+      expect(component.closeModal).toHaveBeenCalled();
+      expect(modalStub.close).toHaveBeenCalled();
+    });
+
+    it('should prevent duplicate refresh requests on rapid double click', () => {
+      const refresh$ = new Subject<AuthTokenInfo>();
+      authServiceStub.refreshAuthenticationToken.and.returnValue(refresh$.asObservable());
+
+      component.extendSessionAndCloseModal();
+      component.extendSessionAndCloseModal();
+
+      expect(authServiceStub.refreshAuthenticationToken).toHaveBeenCalledTimes(1);
+
+      refresh$.next(new AuthTokenInfo('updated-token'));
+      refresh$.complete();
+    });
+
+    it('should not close modal before token refresh completes', () => {
+      const refresh$ = new Subject<AuthTokenInfo>();
+      authServiceStub.refreshAuthenticationToken.and.returnValue(refresh$.asObservable());
+      spyOn(component, 'closeModal').and.callThrough();
+
+      component.extendSessionAndCloseModal();
+
+      expect(component.closeModal).not.toHaveBeenCalled();
+      expect(modalStub.close).not.toHaveBeenCalled();
+
+      refresh$.next(new AuthTokenInfo('updated-token'));
+      refresh$.complete();
+
+      expect(component.closeModal).toHaveBeenCalledTimes(1);
+      expect(modalStub.close).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/app/shared/idle-modal/idle-modal.component.spec.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.spec.ts
@@ -7,7 +7,7 @@ import { IdleModalComponent } from './idle-modal.component';
 import { AuthService } from '../../core/auth/auth.service';
 import { By } from '@angular/platform-browser';
 import { Store } from '@ngrx/store';
-import { LogOutAction } from '../../core/auth/auth.actions';
+import { LogOutAction, RefreshTokenSuccessAction } from '../../core/auth/auth.actions';
 import { AuthTokenInfo } from '../../core/auth/models/auth-token-info.model';
 
 describe('IdleModalComponent', () => {
@@ -21,7 +21,7 @@ describe('IdleModalComponent', () => {
 
   beforeEach(waitForAsync(() => {
     modalStub = jasmine.createSpyObj('modalStub', ['close']);
-    authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'getToken', 'refreshAuthenticationToken', 'replaceToken']);
+    authServiceStub = jasmine.createSpyObj('authService', ['setIdle', 'getToken', 'refreshAuthenticationToken']);
     const token = new AuthTokenInfo('test-token');
     authServiceStub.getToken.and.returnValue(token);
     authServiceStub.refreshAuthenticationToken.and.returnValue(observableOf(token));
@@ -65,13 +65,15 @@ describe('IdleModalComponent', () => {
     });
 
     it('should refresh authentication token with current token', () => {
-      expect(authServiceStub.refreshAuthenticationToken).toHaveBeenCalledWith(authServiceStub.getToken.calls.mostRecent().returnValue);
+      const currentToken = authServiceStub.getToken();
+      expect(authServiceStub.refreshAuthenticationToken).toHaveBeenCalledWith(currentToken);
     });
 
-    it('should replace token before closing modal', () => {
-      const replaceTokenOrder = authServiceStub.replaceToken.calls.first().invocationOrder;
+    it('should dispatch refreshed token before closing modal', () => {
+      expect(storeStub.dispatch).toHaveBeenCalledWith(new RefreshTokenSuccessAction(authServiceStub.getToken()));
+      const dispatchOrder = storeStub.dispatch.calls.first().invocationOrder;
       const closeOrder = modalStub.close.calls.first().invocationOrder;
-      expect(replaceTokenOrder).toBeLessThan(closeOrder);
+      expect(dispatchOrder).toBeLessThan(closeOrder);
     });
   });
 

--- a/src/app/shared/idle-modal/idle-modal.component.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.ts
@@ -6,6 +6,7 @@ import { hasValue } from '../empty.util';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../app.reducer';
 import { LogOutAction } from '../../core/auth/auth.actions';
+import { finalize, take } from 'rxjs/operators';
 
 @Component({
   selector: 'ds-idle-modal',
@@ -23,6 +24,11 @@ export class IdleModalComponent implements OnInit {
    * Timer to track time grace period
    */
   private graceTimer;
+
+  /**
+   * Guards against multiple rapid extension attempts.
+   */
+  private extending = false;
 
   /**
    * An event fired when the modal is closed
@@ -71,11 +77,30 @@ export class IdleModalComponent implements OnInit {
    * Close the modal and extend session
    */
   extendSessionAndCloseModal() {
+    if (this.extending) {
+      return;
+    }
+    this.extending = true;
+
     if (hasValue(this.graceTimer)) {
       clearTimeout(this.graceTimer);
     }
+
     this.authService.setIdle(false);
-    this.closeModal();
+
+    this.authService.refreshAuthenticationToken(this.authService.getToken()).pipe(
+      take(1),
+      finalize(() => this.extending = false)
+    ).subscribe({
+      next: (token) => {
+        this.authService.replaceToken(token);
+        this.closeModal();
+      },
+      error: () => {
+        this.store.dispatch(new LogOutAction());
+        this.closeModal();
+      }
+    });
   }
 
   /**

--- a/src/app/shared/idle-modal/idle-modal.component.ts
+++ b/src/app/shared/idle-modal/idle-modal.component.ts
@@ -5,7 +5,8 @@ import { AuthService } from '../../core/auth/auth.service';
 import { hasValue } from '../empty.util';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../app.reducer';
-import { LogOutAction } from '../../core/auth/auth.actions';
+import { LogOutAction, RefreshTokenSuccessAction } from '../../core/auth/auth.actions';
+import { Subscription } from 'rxjs';
 import { finalize, take } from 'rxjs/operators';
 
 @Component({
@@ -29,6 +30,11 @@ export class IdleModalComponent implements OnInit {
    * Guards against multiple rapid extension attempts.
    */
   private extending = false;
+
+  /**
+   * Tracks the in-flight refresh subscription for cancellation on logout.
+   */
+  private refreshSubscription: Subscription;
 
   /**
    * An event fired when the modal is closed
@@ -88,12 +94,12 @@ export class IdleModalComponent implements OnInit {
 
     this.authService.setIdle(false);
 
-    this.authService.refreshAuthenticationToken(this.authService.getToken()).pipe(
+    this.refreshSubscription = this.authService.refreshAuthenticationToken(this.authService.getToken()).pipe(
       take(1),
       finalize(() => this.extending = false)
     ).subscribe({
       next: (token) => {
-        this.authService.replaceToken(token);
+        this.store.dispatch(new RefreshTokenSuccessAction(token));
         this.closeModal();
       },
       error: () => {
@@ -107,6 +113,8 @@ export class IdleModalComponent implements OnInit {
    * Close the modal and set the response to true so RootComponent knows the modal was closed
    */
   closeModal() {
+    this.refreshSubscription?.unsubscribe();
+    this.extending = false;
     this.activeModal.close();
     this.response.emit(true);
   }


### PR DESCRIPTION
## Problem description

When a user clicks “Extend Session” in the idle modal, the frontend only cleared an idle flag – it did **not** refresh the authentication token. As a result, the token could expire while the user was still considered “active” by the frontend. A hard refresh after extending would then load a stale or expired token, causing role/permission checks (e.g., `canSubmit`) to fail. The “New” submission button would disappear, and the collection modal would show empty data.

## Analysis

The root cause is in `IdleModalComponent.extendSessionAndCloseModal()`. The method only called `setIdle(false)` and closed the modal. No network call was made to refresh the token.

**Why this matters for Shibboleth users:**  
Shibboleth‑issued tokens rely on special groups (`sg` claim) derived from IdP headers. Without a fresh token after session extension, the user loses submit permissions when the token expires. This fix ensures the token is renewed on demand.

*(Note: An additional backend issue was discovered – the backend strips the `sg` claim when refreshing a Shibboleth‑issued token. That issue must be fixed separately in the backend. This PR ensures the frontend performs the refresh correctly.)*

## Problems

No unexpected problems. The change is isolated to `idle-modal.component.ts` and its spec file. The implementation follows existing patterns (same refresh logic used by the automatic token timer).

### Copilot review
- [x] Requested review from Copilot