### PR TITLE
fix(bitstream): restore item UUID in edit redirect

### DIFF
--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
@@ -414,6 +414,19 @@ describe('EditBitstreamPageComponent', () => {
         comp.navigateToItemEditBitstreams();
         expect(router.navigate).toHaveBeenCalledWith([getEntityEditRoute(null, 'some-uuid1'), 'bitstreams']);
       });
+
+      it('should resolve itemId from bundle.item when query param is missing', () => {
+        const mockItem = new Item();
+        mockItem.uuid = 'resolved-uuid-456';
+        const mockBundle = {
+          item: createSuccessfulRemoteDataObject$(mockItem)
+        };
+        (comp as any).bundle = mockBundle;
+        comp.itemId = undefined;
+        comp.navigateToItemEditBitstreams();
+        fixture.detectChanges();
+        expect(router.navigate).toHaveBeenCalledWith([getEntityEditRoute(null, 'resolved-uuid-456'), 'bitstreams']);
+      });
     });
   });
 

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -742,6 +742,23 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
    * otherwise retrieve the item ID based on the owning bundle's link
    */
   navigateToItemEditBitstreams() {
+    if (hasValue(this.itemId)) {
+      this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+      return;
+    }
+    if (hasValue(this.bundle) && hasValue(this.bundle.item)) {
+      this.bundle.item.pipe(
+        getFirstSucceededRemoteDataPayload(),
+        take(1),
+      ).subscribe((item: Item) => {
+        this.itemId = item.uuid;
+        if (!hasValue(this.entityType)) {
+          this.entityType = item.firstMetadataValue('dspace.entity.type');
+        }
+        this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+      });
+      return;
+    }
     this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
   }
 

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -742,24 +742,31 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
    * otherwise retrieve the item ID based on the owning bundle's link
    */
   navigateToItemEditBitstreams() {
+    const navigate = () => this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+
     if (hasValue(this.itemId)) {
-      this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+      navigate();
       return;
     }
+
     if (hasValue(this.bundle) && hasValue(this.bundle.item)) {
       this.bundle.item.pipe(
-        getFirstSucceededRemoteDataPayload(),
-        take(1),
-      ).subscribe((item: Item) => {
-        this.itemId = item.uuid;
-        if (!hasValue(this.entityType)) {
-          this.entityType = item.firstMetadataValue('dspace.entity.type');
+        getFirstCompletedRemoteData(),
+      ).subscribe((itemRd: RemoteData<Item>) => {
+        if (itemRd.hasSucceeded && hasValue(itemRd.payload)) {
+          this.itemId = itemRd.payload.uuid;
+          if (!hasValue(this.entityType)) {
+            this.entityType = itemRd.payload.firstMetadataValue('dspace.entity.type');
+          }
+          navigate();
+        } else {
+          this.location.back();
         }
-        this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
       });
       return;
     }
-    this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+
+    this.location.back();
   }
 
   /**

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -750,19 +750,21 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
     }
 
     if (hasValue(this.bundle) && hasValue(this.bundle.item)) {
-      this.bundle.item.pipe(
-        getFirstCompletedRemoteData(),
-      ).subscribe((itemRd: RemoteData<Item>) => {
-        if (itemRd.hasSucceeded && hasValue(itemRd.payload)) {
-          this.itemId = itemRd.payload.uuid;
-          if (!hasValue(this.entityType)) {
-            this.entityType = itemRd.payload.firstMetadataValue('dspace.entity.type');
+      this.subs.push(
+        this.bundle.item.pipe(
+          getFirstCompletedRemoteData(),
+        ).subscribe((itemRd: RemoteData<Item>) => {
+          if (itemRd.hasSucceeded && hasValue(itemRd.payload)) {
+            this.itemId = itemRd.payload.uuid;
+            if (!hasValue(this.entityType)) {
+              this.entityType = itemRd.payload.firstMetadataValue('dspace.entity.type');
+            }
+            navigate();
+          } else {
+            this.location.back();
           }
-          navigate();
-        } else {
-          this.location.back();
-        }
-      });
+        }),
+      );
       return;
     }
 

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.html
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.html
@@ -112,7 +112,9 @@
                      [attr.data-test]="'download-button' | dsBrowserOnly">
                     <i class="fas fa-download fa-fw"></i>
                   </a>
-                  <button [routerLink]="['/bitstreams/', entry.id, 'edit']" class="btn btn-outline-primary btn-sm"
+                  <button [routerLink]="['/bitstreams/', entry.id, 'edit']"
+                          [queryParams]="{ itemId: item.uuid, entityType: item.firstMetadataValue('dspace.entity.type') }"
+                          class="btn btn-outline-primary btn-sm"
                           [attr.aria-label]="'item.edit.bitstreams.edit.buttons.edit' | translate"
                           title="{{'item.edit.bitstreams.edit.buttons.edit' | translate}}">
                     <i class="fas fa-edit fa-fw"></i>


### PR DESCRIPTION
## Problem description
When editing a bitstream (from the item bitstreams page) and clicking Save or Cancel, the user is redirected to `items/edit/bitstreams` instead of `items/<UUID>/edit/bitstreams`. The item UUID is missing from the redirect URL.

## Analysis
The redirect uses `this.itemId` to construct the URL. This value comes from:
- Route query parameters (`itemId`) – **missing** when navigating from the item bitstreams page edit button.
- Async resolution from `bundle.item` in `ngOnInit` – may not have completed or may be undefined if the link is not resolved on the `Bundle` model.

The edit button in `item-edit-bitstream-bundle.component.html` only uses `[routerLink]` without passing query params. The fallback logic in `navigateToItemEditBitstreams()` was removed previously, so navigation proceeds with `undefined` itemId.

### Copilot review
- [x] Requested review from Copilot