### PR TITLE
issue 162: filter clarinusermetadata/manage payload to contain only required metadata keys

### DIFF
--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -118,6 +118,11 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
   LICENSE_PATH_SEZNAM_CZ = 'szn-dataset-licence.html';
 
   /**
+   * The list of metadata keys that are optional and do not require user input.
+   */
+  OPTIONAL_METADATA_KEYS = ['ORGANIZATION'];
+
+  /**
    * The content of the Seznam dataset license. Fetch from the static file.
    */
   licenseContentSeznam: BehaviorSubject<string> = new BehaviorSubject<string>('');
@@ -209,8 +214,11 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
       this.getBitstreamUUID();
     if (this.userMetadata$.value?.page) {
       // Filter the page array to exclude items with metadataKey "IP"
+      // and exclude items that are not in the requiredInfo list
       this.userMetadata$.value.page =
-        this.userMetadata$.value.page.filter(item => item.metadataKey !== 'IP');
+        this.userMetadata$.value.page.filter(item => item.metadataKey !== 'IP' &&
+          this.requiredInfo$?.value?.some(requiredInfo =>
+            requiredInfo.name === item.metadataKey));
     }
     // Add IP address into request. Every restricted download must have stored IP address in the `user_metadata` table.
     this.userMetadata$.value?.page.push(Object.assign(new ClarinUserMetadata(), {
@@ -422,13 +430,18 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     // Every requiredInfo.name === userMetadata.metadataKey must have the value in the userMetadata.metadataValue
     this.requiredInfo$?.value?.forEach(requiredInfo => {
       let hasMetadataValue = false;
-      this.userMetadata$?.value?.page?.forEach(userMetadata => {
-        if (userMetadata.metadataKey === requiredInfo.name) {
-          if (isNotEmpty(userMetadata.metadataValue)) {
-            hasMetadataValue = true;
+      // The OPTIONAL metadata keys don't require user input, so we consider them as filled in
+      if (this.OPTIONAL_METADATA_KEYS.includes(requiredInfo.name)) {
+        hasMetadataValue = true;
+      } else {
+        this.userMetadata$?.value?.page?.forEach(userMetadata => {
+          if (userMetadata.metadataKey === requiredInfo.name) {
+            if (isNotEmpty(userMetadata.metadataValue)) {
+              hasMetadataValue = true;
+            }
           }
-        }
-      });
+        });
+      }
       areFilledIn.push(hasMetadataValue);
     });
 


### PR DESCRIPTION
This fixes **(1)**: https://github.com/ufal/dspace-angular/issues/162

The list of ClarinUserMetadata values is now filtered to metadata values only required by the license definition.

and `(2)` the issue with "ORGANIZATION" (optional) metadata value.
There are two organization metadata keys:
```
ORGANIZATION (optional)
REQUIRED_ORGANIZATION (mandatory)
```
When the license had checked ORGANIZATION (optional), user was still enforced to fill in the value, thought the value is optional.
This was fixed as well.


