### PR TITLE
fix(file-description): display "N/A" when file description is empty

### DIFF
--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
@@ -22,7 +22,7 @@
       </dd>
       <dt>{{'item.file.description.description' | translate}}</dt>
       <dd>
-        {{ fileInput.description }}
+        {{ (fileInput.description) || ('item.file.description.na' | translate) }}
       </dd>
       <dt>{{'item.file.description.checksum' | translate}}</dt>
       <dd>

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
@@ -100,4 +100,22 @@ describe('FileDescriptionComponent', () => {
     ).nativeElement;
     expect(fileNameElement.textContent).toContain('testFile');
   });
+
+  it('should show the fallback translation key when description is empty', () => {
+    component.fileInput.description = '';
+    fixture.detectChanges();
+
+    const descElement = fixture.debugElement.queryAll(By.css('.file-content dd'))[3];
+    expect(descElement).toBeTruthy();
+    expect(descElement.nativeElement.textContent).toContain('item.file.description.na');
+  });
+
+  it('should show the description text when description is present', () => {
+    component.fileInput.description = 'This is a test description';
+    fixture.detectChanges();
+
+    const descElement = fixture.debugElement.queryAll(By.css('.file-content dd'))[3];
+    expect(descElement).toBeTruthy();
+    expect(descElement.nativeElement.textContent).toContain('This is a test description');
+  });
 });

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
@@ -105,17 +105,21 @@ describe('FileDescriptionComponent', () => {
     component.fileInput.description = '';
     fixture.detectChanges();
 
-    const descElement = fixture.debugElement.queryAll(By.css('.file-content dd'))[3];
-    expect(descElement).toBeTruthy();
-    expect(descElement.nativeElement.textContent).toContain('item.file.description.na');
+    const descDt = fixture.debugElement.queryAll(By.css('.file-content dt'))
+       .find((de) => (de.nativeElement as HTMLElement).textContent?.includes('item.file.description.description'));
+     expect(descDt).toBeTruthy();
+     const descElement = (descDt!.nativeElement as HTMLElement).nextElementSibling as HTMLElement;
+     expect(descElement.textContent).toContain('item.file.description.na');
   });
 
   it('should show the description text when description is present', () => {
     component.fileInput.description = 'This is a test description';
     fixture.detectChanges();
 
-    const descElement = fixture.debugElement.queryAll(By.css('.file-content dd'))[3];
-    expect(descElement).toBeTruthy();
-    expect(descElement.nativeElement.textContent).toContain('This is a test description');
+    const descDt = fixture.debugElement.queryAll(By.css('.file-content dt'))
+       .find((de) => (de.nativeElement as HTMLElement).textContent?.includes('item.file.description.description'));
+     expect(descDt).toBeTruthy();
+     const descElement = (descDt!.nativeElement as HTMLElement).nextElementSibling as HTMLElement;
+     expect(descElement.textContent).toContain('This is a test description');
   });
 });

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -527,6 +527,18 @@
   // "admin.access-control.epeople.form.notification.deleted.failure": "Failed to delete EPerson \"{{name}}\"",
   "admin.access-control.epeople.form.notification.deleted.failure": "Nepodařilo se smazat uživatele \"{{name}}\"",
 
+  // "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
+  "admin.access-control.epeople.notification.deleted.forbidden.self": "Nemůžete smazat svůj vlastní účet uživatele.",
+
+  // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
+  "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
+
+  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel má oprávnění správce. Smazání tohoto uživatele odebere účet správce.",
+
+  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Upozornění: Tento uživatel odeslal položky a má oprávnění správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
+
   // "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
   "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Člen těchto skupin:",
 
@@ -550,18 +562,6 @@
 
   // "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
   "admin.access-control.epeople.notification.deleted.success": "Úspěšně odstraněn uživatel: \"{{name}}\"",
-
-  // "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
-  "admin.access-control.epeople.notification.deleted.forbidden.self": "Nemůžete smazat svůj vlastní účet uživatele.",
-
-  // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
-  "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
-
-  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
-  "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel má oprávnění správce. Smazání tohoto uživatele odebere účet správce.",
-
-  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
-  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Upozornění: Tento uživatel odeslal položky a má oprávnění správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
 
   // "admin.access-control.groups.title": "Groups",
   "admin.access-control.groups.title": "Skupiny",
@@ -4632,6 +4632,10 @@
   // "menu.section.icon.workflow": "Administer workflow menu section",
   "menu.section.icon.workflow": "Sekce menu pro administrativní workflow",
 
+  // "menu.section.icon.update_config": "Update Configuration menu section",
+  // TODO New key - Add a translation
+  "menu.section.icon.update_config": "Update Configuration menu section",
+
   // "menu.section.icon.unpin": "Unpin sidebar",
   "menu.section.icon.unpin": "Odepnout postranní panel",
 
@@ -8211,6 +8215,9 @@
   // "menu.section.system-wide-alert": "System-wide Alert",
   "menu.section.system-wide-alert": "Systémová upozornění",
 
+  // "menu.section.update-config": "Update Config",
+  "menu.section.update-config": "Úprava konfigurace",
+
   // "system-wide-alert.form.header": "System-wide Alert",
   "system-wide-alert.form.header": "Systémová upozornění",
 
@@ -8258,12 +8265,6 @@
 
   // "system-wide-alert.form.create.error": "Something went wrong when creating the system-wide alert",
   "system-wide-alert.form.create.error": "Něco se pokazilo při vytváření systémového upozornění",
-
-  // "admin.system-wide-alert.breadcrumbs": "System-wide Alerts",
-  "admin.system-wide-alert.breadcrumbs": "Systémová upozornění",
-
-  // "admin.system-wide-alert.title": "System-wide Alerts",
-  "admin.system-wide-alert.title": "Systémová upozornění",
 
   // "admin.update-config.title": "Update Configuration",
   "admin.update-config.title": "Aktualizace konfigurace",
@@ -8340,179 +8341,150 @@
   // Additional translation keys for enhanced UI
   // "admin.update-config.refresh": "Refresh",
   "admin.update-config.refresh": "Obnovit",
-
   // "admin.update-config.refresh.tooltip": "Reload configuration files list",
   "admin.update-config.refresh.tooltip": "Znovu načíst seznam konfiguračních souborů",
-
   // "admin.update-config.loading": "Loading...",
   "admin.update-config.loading": "Načítání...",
-
   // "admin.update-config.loading-files": "Loading configuration files...",
   "admin.update-config.loading-files": "Načítání konfiguračních souborů...",
-
   // "admin.update-config.loading-content": "Loading file content...",
   "admin.update-config.loading-content": "Načítání obsahu souboru...",
 
   // "admin.update-config.file-selection.title": "File Selection",
   "admin.update-config.file-selection.title": "Výběr souboru",
-
   // "admin.update-config.file-selection.label": "Select Configuration File",
   "admin.update-config.file-selection.label": "Vyberte konfigurační soubor",
 
   // "admin.update-config.file-info.path": "Path",
   "admin.update-config.file-info.path": "Cesta",
-
   // "admin.update-config.file-info.modified": "Last Modified",
   "admin.update-config.file-info.modified": "Naposledy změněno",
 
   // "admin.update-config.select.choose-file": "Choose a configuration file to edit",
   "admin.update-config.select.choose-file": "Vyberte konfigurační soubor k editaci",
-
   // "admin.update-config.select.no-files": "No configuration files found",
   "admin.update-config.select.no-files": "Nenalezeny žádné konfigurační soubory",
 
   // "admin.update-config.editor.title": "Configuration Editor",
   "admin.update-config.editor.title": "Editor konfigurace",
-
   // "admin.update-config.editor.content": "File Content",
   "admin.update-config.editor.content": "Obsah souboru",
-
   // "admin.update-config.editor.placeholder": "Select a file to begin editing...",
   "admin.update-config.editor.placeholder": "Vyberte soubor pro zahájení editace...",
-
   // "admin.update-config.editor.characters": "characters",
   "admin.update-config.editor.characters": "znaků",
-
   // "admin.update-config.editor.save": "Save Changes",
   "admin.update-config.editor.save": "Uložit změny",
-
   // "admin.update-config.editor.save.tooltip": "Save changes to the configuration file",
   "admin.update-config.editor.save.tooltip": "Uložit změny do konfiguračního souboru",
-
   // "admin.update-config.editor.reset": "Reset",
   "admin.update-config.editor.reset": "Obnovit",
-
   // "admin.update-config.editor.reset.tooltip": "Reset content to original version",
   "admin.update-config.editor.reset.tooltip": "Obnovit obsah na původní verzi",
 
   // "admin.update-config.validation.valid": "Configuration is valid",
   "admin.update-config.validation.valid": "Konfigurace je platná",
-
   // "admin.update-config.validation.invalid": "Configuration contains errors - please fix before saving",
   "admin.update-config.validation.invalid": "Konfigurace obsahuje chyby - prosím opravte před uložením",
-
   // "admin.update-config.validation.unsaved-changes": "File has unsaved changes",
   "admin.update-config.validation.unsaved-changes": "Soubor má neuložené změny",
 
   // "admin.update-config.help.important.title": "Before You Start",
   "admin.update-config.help.important.title": "Než začnete",
-
   // "admin.update-config.help.important.backup": "Always backup configuration files before making changes",
   "admin.update-config.help.important.backup": "Vždy zálohujte konfigurační soubory před prováděním změn",
-
   // "admin.update-config.help.important.restart": "DSpace may require restart after configuration changes",
   "admin.update-config.help.important.restart": "DSpace může vyžadovat restart po změnách konfigurace",
-
   // "admin.update-config.help.important.validation": "Configuration validation prevents saving invalid files",
   "admin.update-config.help.important.validation": "Validace konfigurace předchází uložení neplatných souborů",
 
   // "admin.update-config.help.allowed-files.title": "Editable Files",
   "admin.update-config.help.allowed-files.title": "Editovatelné soubory",
-
-  // "admin.update-config.help.allowed-files.description": "Only XML files in the config-be directory can be edited for security reasons:",
-  "admin.update-config.help.allowed-files.description": "Pouze XML soubory v adresáři config-be mohou být editovány z bezpečnostních důvodů:",
+  // "admin.update-config.help.allowed-files.description": "Only configuration files in the server configuration directory can be edited for security reasons:",
+  // TODO New key - Add a translation
+  "admin.update-config.help.allowed-files.description": "Only configuration files in the server configuration directory can be edited for security reasons:",
 
   // "admin.update-config.error.load-files.title": "Load Error",
   "admin.update-config.error.load-files.title": "Chyba načtení",
-
   // "admin.update-config.error.load-files.message": "Failed to load configuration files list",
   "admin.update-config.error.load-files.message": "Nepodařilo se načíst seznam konfiguračních souborů",
 
   // Breadcrumb
+  // "admin.update-config.breadcrumbs": "Update Configuration",
   "admin.update-config.breadcrumbs": "Aktualizace konfigurace",
 
   // File Information
   // "admin.update-config.file-info.title": "File Information",
   "admin.update-config.file-info.title": "Informace o souboru",
-
   // "admin.update-config.file-info.name": "File",
   "admin.update-config.file-info.name": "Soubor",
-
   // "admin.update-config.file-info.size": "Size",
   "admin.update-config.file-info.size": "Velikost",
-
   // "admin.update-config.file-info.bytes": "bytes",
   "admin.update-config.file-info.bytes": "bajtů",
-
   // "admin.update-config.file-info.modified": "Modified",
-  "admin.update-config.file-info.modified": "Změněno",
-
+  // TODO Source message changed - Revise the translation
+  "admin.update-config.file-info.modified": "Naposledy změněno",
   // "admin.update-config.file-info.status": "Status",
   "admin.update-config.file-info.status": "Stav",
-
   // "admin.update-config.file-info.ready": "Ready for editing",
   "admin.update-config.file-info.ready": "Připraven k editaci",
 
   // Action Buttons
   // "admin.update-config.buttons.undo": "Undo Changes",
   "admin.update-config.buttons.undo": "Vrátit změny",
-
   // "admin.update-config.buttons.undo.tooltip": "Reset to last saved version",
   "admin.update-config.buttons.undo.tooltip": "Obnovit na poslední uloženou verzi",
-
   // "admin.update-config.buttons.reload": "Reload File",
   "admin.update-config.buttons.reload": "Znovu načíst soubor",
-
   // "admin.update-config.buttons.reload.tooltip": "Reload file from server",
   "admin.update-config.buttons.reload.tooltip": "Znovu načíst soubor ze serveru",
-
   // "admin.update-config.buttons.save": "Save to File",
   "admin.update-config.buttons.save": "Uložit do souboru",
-
   // "admin.update-config.buttons.save.tooltip": "Save changes to configuration file",
   "admin.update-config.buttons.save.tooltip": "Uložit změny do konfiguračního souboru",
-
   // "admin.update-config.buttons.saving": "Saving to File...",
   "admin.update-config.buttons.saving": "Ukládání do souboru...",
 
   // Editor Notice
   // "admin.update-config.editor.notice.title": "File Editor",
   "admin.update-config.editor.notice.title": "Editor souborů",
-
   // "admin.update-config.editor.notice.description": "Editing configuration file {{fileName}}. Changes are saved immediately to the server.",
   "admin.update-config.editor.notice.description": "Editace konfiguračního souboru {{fileName}}. Změny jsou ukládány okamžitě na server.",
 
   // Success Messages
   // "admin.update-config.success.save.title": "File Saved Successfully",
-  "admin.update-config.success.save.title": "Soubor úspěšně uložen",
-
+  // TODO Source comments changed - Revise the translation
+  // TODO Source message changed - Revise the translation
+  "admin.update-config.success.save.title": "Konfigurace uložena",
   // "admin.update-config.success.save.message": "{{fileName}} has been updated successfully",
-  "admin.update-config.success.save.message": "{{fileName}} byl úspěšně aktualizován",
-
+  // TODO Source message changed - Revise the translation
+  "admin.update-config.success.save.message": "{{message}}",
   // "admin.update-config.success.reload.title": "File Reloaded",
   "admin.update-config.success.reload.title": "Soubor znovu načten",
-
   // "admin.update-config.success.reload.message": "Reloaded {{fileName}} from server",
   "admin.update-config.success.reload.message": "{{fileName}} byl znovu načten ze serveru",
 
   // Error Messages
   // "admin.update-config.error.load-content.title": "Load Failed",
   "admin.update-config.error.load-content.title": "Načtení selhalo",
-
   // "admin.update-config.error.load-content.message": "Could not load {{fileName}}",
   "admin.update-config.error.load-content.message": "Nepodařilo se načíst {{fileName}}",
-
   // "admin.update-config.error.save.title": "Save Failed",
   "admin.update-config.error.save.title": "Uložení selhalo",
-
   // "admin.update-config.error.save.message": "Could not save {{fileName}}",
-  "admin.update-config.error.save.message": "Nepodařilo se uložit {{fileName}}",
-
+  // TODO Source message changed - Revise the translation
+  "admin.update-config.error.save.message": "Nepodařilo se uložit konfigurační soubor. Zkontrolujte logy a zkuste to znovu.",
   // "admin.update-config.error.reload.title": "Reload Failed",
   "admin.update-config.error.reload.title": "Opětovné načtení selhalo",
-
   // "admin.update-config.error.reload.message": "Could not reload original file",
   "admin.update-config.error.reload.message": "Nepodařilo se znovu načíst původní soubor",
+
+  // "admin.system-wide-alert.breadcrumbs": "System-wide Alerts",
+  "admin.system-wide-alert.breadcrumbs": "Systémová upozornění",
+
+  // "admin.system-wide-alert.title": "System-wide Alerts",
+  "admin.system-wide-alert.title": "Systémová upozornění",
 
   // "item-access-control-title": "This form allows you to perform changes to the access conditions of the item's metadata or its bitstreams.",
   "item-access-control-title": "Tento formulář umožňuje provést změny typu přístupu k metadatovému záznamu nebo souborům.",
@@ -8605,17 +8577,25 @@
   "access-control-option-end-date": "Povolit přístup do",
 
   // "access-control-option-end-date-note": "Select the date until which the related access condition is applied",
-
   "item.delete.virtual-metadata.info": "Zobrazit informace o virtuálních metadatech",
-  "access-control.start-date.calendar-button": "Otevřít kalendář počátečního data",
-  "access-control.end-date.calendar-button": "Otevřít kalendář koncového data",
-  "form.remove-related-item": "Odebrat související položku",
-  "form.relation-group.save": "Uložit skupinu vztahů",
-  "form.relation-group.delete": "Smazat skupinu vztahů",
-  "form.relation-group.clear": "Vyčistit skupinu vztahů",
-  "submission.cc-license.field-info": "Více informací o tomto licenčním poli",
-  "access-control-option-end-date-note": "Vyberte datum, do kterého má být typ přístupu aktivován",
 
+  // "item.delete.virtual-metadata.info": "Show virtual metadata information",
+  // TODO Source message changed - Revise the translation
+  "item.delete.virtual-metadata.info": "Zobrazit informace o virtuálních metadatech",
+  // "access-control.start-date.calendar-button": "Open start date calendar",
+  "access-control.start-date.calendar-button": "Otevřít kalendář počátečního data",
+  // "access-control.end-date.calendar-button": "Open end date calendar",
+  "access-control.end-date.calendar-button": "Otevřít kalendář koncového data",
+  // "form.remove-related-item": "Remove related item",
+  "form.remove-related-item": "Odebrat související položku",
+  // "form.relation-group.save": "Save relation group",
+  "form.relation-group.save": "Uložit skupinu vztahů",
+  // "form.relation-group.delete": "Delete relation group",
+  "form.relation-group.delete": "Smazat skupinu vztahů",
+  // "form.relation-group.clear": "Clear relation group",
+  "form.relation-group.clear": "Vyčistit skupinu vztahů",
+  // "submission.cc-license.field-info": "More information about this license field",
+  "submission.cc-license.field-info": "Více informací o tomto licenčním poli",
   // "vocabulary-treeview.search.form.add": "Add",
   "vocabulary-treeview.search.form.add": "Přidat",
 
@@ -9213,6 +9193,9 @@
   // "item.file.description.description": "Description",
   "item.file.description.description": "Popis",
 
+  // "item.file.description.na": "N/A",
+  "item.file.description.na": "Neuvedeno",
+
   // "item.file.description.checksum": "MD5",
   "item.file.description.checksum": "MD5",
 
@@ -9230,8 +9213,11 @@
 
   // "item.page.download.button.command.line": "Download instructions for command line",
   "item.page.download.button.command.line": "Instrukce pro stažení z příkazové řádky",
+  // "item.page.download.command.copy": "Copy to clipboard",
   "item.page.download.command.copy": "Kopírovat",
+  // "item.page.download.command.copied": "Copied!",
   "item.page.download.command.copied": "Zkopírováno!",
+  // "item.page.download.command.close": "Close",
   "item.page.download.command.close": "Zavřít",
 
   // "item.page.download.button.all.files.zip": "Download all files in item",
@@ -9381,9 +9367,6 @@
   // "menu.section.licenses": "License Administration",
   "menu.section.licenses": "Správa licencí",
 
-  // "menu.section.update-config": "Update Config",
-  "menu.section.update-config": "Úprava konfigurace",
-
   // "menu.section.submissions": "Submissions",
   "menu.section.submissions": "Příspěvky",
 
@@ -9482,118 +9465,80 @@
 
   // "clarin-license.define-license-form.submit-button": "Save",
   "clarin-license.define-license-form.submit-button": "Uložit",
-
   // "clarin.license.label.section.title": "License Labels",
   "clarin.license.label.section.title": "Licenční štítky",
-
   // "clarin.license.label.table.header.label": "Label",
   "clarin.license.label.table.header.label": "Štítek",
-
   // "clarin.license.label.table.header.title": "Title",
   "clarin.license.label.table.header.title": "Název",
-
   // "clarin.license.label.table.header.extended": "Extended",
   "clarin.license.label.table.header.extended": "Rozšířený",
-
   // "clarin.license.label.table.header.icon": "Icon",
   "clarin.license.label.table.header.icon": "Ikona",
-
   // "clarin.license.label.table.header.actions": "Actions",
   "clarin.license.label.table.header.actions": "Akce",
-
   // "clarin.license.label.table.boolean.yes": "Yes",
   "clarin.license.label.table.boolean.yes": "Ano",
-
   // "clarin.license.label.table.boolean.no": "No",
   "clarin.license.label.table.boolean.no": "Ne",
-
   // "clarin.license.label.table.icon.available": "Icon available",
   "clarin.license.label.table.icon.available": "Ikona je k dispozici",
-
   // "clarin.license.label.table.icon.none": "No icon",
   "clarin.license.label.table.icon.none": "Bez ikony",
-
   // "clarin.license.label.table.select.aria": "Select label {{label}}",
   "clarin.license.label.table.select.aria": "Vybrat štítek {{label}}",
-
   // "clarin.license.label.table.edit": "Edit",
   "clarin.license.label.table.edit": "Upravit",
-
   // "clarin.license.label.table.edit.aria": "Edit label {{label}}",
   "clarin.license.label.table.edit.aria": "Upravit štítek {{label}}",
-
   // "clarin.license.label.table.delete": "Delete",
   "clarin.license.label.table.delete": "Odstranit",
-
   // "clarin.license.label.table.delete.aria": "Delete label {{label}}",
   "clarin.license.label.table.delete.aria": "Odstranit štítek {{label}}",
-
   // "clarin.license.label.table.delete.disabled-tooltip": "Label \"{{label}}\" cannot be deleted because it is assigned to one or more licenses.",
   "clarin.license.label.table.delete.disabled-tooltip": "Štítek \"{{label}}\" nelze odstranit, protože je přiřazen k jedné nebo více licencím.",
-
   // "clarin.license.label.table.delete.checking-tooltip": "Checking whether this label is in use…",
   "clarin.license.label.table.delete.checking-tooltip": "Zjišťuje se, zda se tento štítek používá…",
-
   // "clarin.license.label.table.empty": "No license labels available.",
   "clarin.license.label.table.empty": "Nejsou k dispozici žádné licenční štítky.",
-
   // "clarin.license.label.table.loading": "Loading labels...",
   "clarin.license.label.table.loading": "Načítají se licenční štítky...",
-
   // "clarin.license.label.create.title": "Define License Label",
   "clarin.license.label.create.title": "Definovat licenční štítek",
-
   // "clarin.license.label.create.submit": "Save",
   "clarin.license.label.create.submit": "Uložit",
-
   // "clarin.license.label.create.success": "License label created successfully.",
   "clarin.license.label.create.success": "Licenční štítek byl úspěšně vytvořen.",
-
   // "clarin.license.label.create.error": "Failed to create license label.",
   "clarin.license.label.create.error": "Nepodařilo se vytvořit licenční štítek.",
-
   // "clarin.license.label.load.error": "Failed to load license labels.",
   "clarin.license.label.load.error": "Nepodařilo se načíst licenční štítky.",
-
   // "clarin.license.label.edit.title": "Edit License Label",
   "clarin.license.label.edit.title": "Upravit licenční štítek",
-
   // "clarin.license.label.edit.submit": "Save Changes",
   "clarin.license.label.edit.submit": "Uložit změny",
-
   // "clarin.license.label.edit.icon.note": "Leave empty to keep current icon.",
   "clarin.license.label.edit.icon.note": "Ponechte prázdné, chcete-li zachovat stávající ikonu.",
-
   // "clarin.license.label.edit.icon.preview": "Current icon",
   "clarin.license.label.edit.icon.preview": "Stávající ikona",
-
   // "clarin.license.label.edit.icon.clear": "Remove current icon",
   "clarin.license.label.edit.icon.clear": "Odstranit stávající ikonu",
-
   // "clarin.license.label.edit.success": "License label updated successfully.",
   "clarin.license.label.edit.success": "Licenční štítek byl úspěšně aktualizován.",
-
   // "clarin.license.label.edit.error": "Failed to update license label.",
   "clarin.license.label.edit.error": "Nepodařilo se aktualizovat licenční štítek.",
-
   // "clarin.license.label.modal.close": "Close",
   "clarin.license.label.modal.close": "Zavřít",
-
   // "clarin.license.label.delete.confirm.title": "Delete License Label \"{{ dsoName }}\"",
   "clarin.license.label.delete.confirm.title": "Odstranit licenční štítek \"{{ dsoName }}\"",
-
   // "clarin.license.label.delete.confirm.message": "Are you sure you want to delete the label \"{{ dsoName }}\"? This action cannot be undone.",
   "clarin.license.label.delete.confirm.message": "Opravdu chcete odstranit štítek \"{{ dsoName }}\"? Tuto akci nelze vrátit zpět.",
-
   // "clarin.license.label.delete.confirm.button": "Delete",
   "clarin.license.label.delete.confirm.button": "Odstranit",
-
   // "clarin.license.label.delete.cancel.button": "Cancel",
   "clarin.license.label.delete.cancel.button": "Zrušit",
-
   // "clarin.license.label.delete.success": "License label deleted successfully.",
   "clarin.license.label.delete.success": "Licenční štítek byl úspěšně odstraněn.",
-
   // "clarin.license.label.delete.error": "Failed to delete license label.",
   "clarin.license.label.delete.error": "Nepodařilo se odstranit licenční štítek.",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -8458,8 +8458,7 @@
   // TODO Source message changed - Revise the translation
   "admin.update-config.success.save.title": "Konfigurace uložena",
   // "admin.update-config.success.save.message": "{{fileName}} has been updated successfully",
-  // TODO Source message changed - Revise the translation
-  "admin.update-config.success.save.message": "{{message}}",
+  "admin.update-config.success.save.message": "{{fileName}} byl úspěšně aktualizován",
   // "admin.update-config.success.reload.title": "File Reloaded",
   "admin.update-config.success.reload.title": "Soubor znovu načten",
   // "admin.update-config.success.reload.message": "Reloaded {{fileName}} from server",
@@ -8577,7 +8576,7 @@
   "access-control-option-end-date": "Povolit přístup do",
 
   // "access-control-option-end-date-note": "Select the date until which the related access condition is applied",
-  "item.delete.virtual-metadata.info": "Zobrazit informace o virtuálních metadatech",
+  "access-control-option-end-date-note": "Vyberte datum, do kterého má být typ přístupu aktivován",
 
   // "item.delete.virtual-metadata.info": "Show virtual metadata information",
   // TODO Source message changed - Revise the translation

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6108,6 +6108,8 @@
 
   "item.file.description.description": "Description",
 
+  "item.file.description.na": "N/A",
+
   "item.file.description.checksum": "MD5",
 
   "item.file.description.download.file": "Download file",


### PR DESCRIPTION
## Problem description
File description field rendered blank when no description was provided. Now displays "N/A" (or its Czech translation "Neuvedeno") as a fallback.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [x] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Copilot review
- [x] Requested review from Copilot