### PR TITLE
fix(subject-badge): add text-wrap and text-left to prevent overflow

### DIFF
--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
@@ -31,7 +31,7 @@
           <span *ngIf="!last" [innerHTML]="separator"></span>
         </span>
         <span *ngIf="type === 'subject'" class="pr-1">
-          <a class="badge badge-info text-white cursor-pointer mr-1"
+          <a class="badge text-wrap text-left badge-info text-white cursor-pointer mr-1"
              *ngFor="let subject of mdValue.value.split(separator);"
              [href]="getLinkToSearch(-1, subject)">
             {{subject}}


### PR DESCRIPTION
## Problem description
Long subject keywords on the item page were overflowing the badge area and wrapping text was centered, making it hard to read.

## Analysis

## Problems

### Copilot review
- [x] Requested review from Copilot