### PR TITLE
CI: redeploy ok-dspace on pushes to clarin-v7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,16 +83,24 @@ jobs:
     needs: [dspace-angular-dist]
     runs-on: ubuntu-latest
     # This job authenticates with a PAT and never uses GITHUB_TOKEN, so it needs
-    # none of the workflow-level permissions. Dropping them limits what a
-    # compromised third-party action could reach from here.
+    # none of the workflow-level permissions at all.
     permissions: {}
     steps:
+      # One POST, hand-rolled with the `gh` and `jq` that ubuntu-latest already
+      # ships, rather than a third-party dispatch action: a single API call is
+      # not worth a supply-chain dependency that runs with the PAT in its
+      # environment.
       - name: Notify ufal/dspace-k8s
-        uses: peter-evans/repository-dispatch@v4
-        with:
+        env:
           # Fine-grained PAT, scoped to ufal/dspace-k8s only, Contents: write
           # (what POST /repos/{owner}/{repo}/dispatches requires).
-          token: ${{ secrets.OK_DSPACE_DEPLOY_TOKEN }}
-          repository: ufal/dspace-k8s
-          event-type: deploy-ok-dspace
-          client-payload: '{"component":"frontend","sha":"${{ github.sha }}"}'
+          GH_TOKEN: ${{ secrets.OK_DSPACE_DEPLOY_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # jq builds the payload from an --arg, so the value is a JSON string
+          # by construction rather than by careful quoting.
+          jq -n --arg sha "${SHA}" \
+            '{event_type: "deploy-ok-dspace",
+              client_payload: {component: "frontend", sha: $sha}}' \
+            | gh api -X POST repos/ufal/dspace-k8s/dispatches --input -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,11 +62,31 @@ jobs:
       REDEPLOY_SANDBOX_URL:  ${{ secrets.REDEPLOY_SANDBOX_URL }}
       REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}
 
-      #  deploy:
-      #    needs: dspace-angular
-      #    uses: ufal/dspace-angular/.github/workflows/deploy.yml@clarin-v7
-      #    if: ${{ github.event_name != 'pull_request' }}
-      #    with:
-      #      INSTANCE: '5'
-      #      IMPORT: false
-      #    secrets: inherit
+  ###########################################################################
+  # Redeploy the ok-dspace test environment (ufal/dspace-k8s, ns kosarko-ns)
+  ###########################################################################
+  # Replaces the old commented-out deploy stub, which targeted the dataquest
+  # docker-compose instances (dev-5/dev-8) we no longer have access to.
+  #
+  # Runs only for pushes to the default branch, after the image this
+  # environment consumes has actually been pushed. This job only records the
+  # new version: it sends a repository_dispatch to ufal/dspace-k8s, which pins
+  # the tag to git, and a reconciler inside the cluster picks it up. No
+  # deployment step and no cluster credential exists in this repository - or in
+  # GitHub at all.
+  deploy-ok-dspace:
+    if: github.repository == 'ufal/dspace-angular' && github.event_name == 'push' && github.ref_name == 'clarin-v7'
+    # dspace-angular-dist, NOT dspace-angular: the latter builds the '-dev'
+    # suffixed image, while the overlay runs the unsuffixed dist image.
+    needs: [dspace-angular-dist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deployment
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          # Fine-grained PAT, scoped to ufal/dspace-k8s only, Contents: write
+          # (what POST /repos/{owner}/{repo}/dispatches requires).
+          token: ${{ secrets.OK_DSPACE_DEPLOY_TOKEN }}
+          repository: ufal/dspace-k8s
+          event-type: deploy-ok-dspace
+          client-payload: '{"component":"frontend","sha":"${{ github.sha }}"}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,10 @@ jobs:
     # suffixed image, while the overlay runs the unsuffixed dist image.
     needs: [dspace-angular-dist]
     runs-on: ubuntu-latest
+    # This job authenticates with a PAT and never uses GITHUB_TOKEN, so it needs
+    # none of the workflow-level permissions. Dropping them limits what a
+    # compromised third-party action could reach from here.
+    permissions: {}
     steps:
       - name: Notify ufal/dspace-k8s
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,17 +63,19 @@ jobs:
       REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}
 
   ###########################################################################
-  # Redeploy the ok-dspace test environment (ufal/dspace-k8s, ns kosarko-ns)
+  # Notify ufal/dspace-k8s of a new build, for the ok-dspace test environment
   ###########################################################################
   # Replaces the old commented-out deploy stub, which targeted the dataquest
   # docker-compose instances (dev-5/dev-8) we no longer have access to.
   #
-  # Runs only for pushes to the default branch, after the image this
-  # environment consumes has actually been pushed. This job only records the
-  # new version: it sends a repository_dispatch to ufal/dspace-k8s, which pins
-  # the tag to git, and a reconciler inside the cluster picks it up. No
-  # deployment step and no cluster credential exists in this repository - or in
-  # GitHub at all.
+  # Runs only for pushes to `clarin-v7` - currently the default branch, named
+  # explicitly here because that is exactly what the guard below matches - and
+  # only after the image this environment consumes has actually been pushed.
+  #
+  # This job records a new version; it does not deploy. It sends a
+  # repository_dispatch to ufal/dspace-k8s, which pins the tag to git, and a
+  # reconciler inside that cluster applies it. No deployment step and no cluster
+  # credential exists in this repository, or anywhere in GitHub.
   deploy-ok-dspace:
     if: github.repository == 'ufal/dspace-angular' && github.event_name == 'push' && github.ref_name == 'clarin-v7'
     # dspace-angular-dist, NOT dspace-angular: the latter builds the '-dev'
@@ -81,7 +83,7 @@ jobs:
     needs: [dspace-angular-dist]
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger deployment
+      - name: Notify ufal/dspace-k8s
         uses: peter-evans/repository-dispatch@v4
         with:
           # Fine-grained PAT, scoped to ufal/dspace-k8s only, Contents: write


### PR DESCRIPTION
Replaces the commented-out `deploy:` stub with a `deploy-ok-dspace` job that notifies
[`ufal/dspace-k8s`](https://github.com/ufal/dspace-k8s) once the image this test environment consumes
has been pushed. Target environment: <https://ok-dspace.dyn.cloud.e-infra.cz>.

The old stub targeted the dataquest docker-compose instances (`dev-5`/`dev-8`) we no longer have
access to, which is why it was commented out rather than maintained.

**This job records a version; it does not deploy.** It sends a `repository_dispatch`; `dspace-k8s`
pins the tag to git and a reconciler inside the cluster applies it. No deployment step and no cluster
credential exists in this repository — or anywhere in GitHub.

- `needs: [dspace-angular-dist]`, **not** `dspace-angular` — the latter builds the `-dev` suffixed
  image, while the overlay runs the unsuffixed dist image. Easy to get backwards.
- Runs only for **pushes to `clarin-v7` in `ufal/dspace-angular`**, so a pull request builds the
  image but never triggers a deploy, and forks never fire it.
- `secrets.OK_DSPACE_DEPLOY_TOKEN` is a fine-grained PAT scoped to `ufal/dspace-k8s` with
  **Contents: write**, which is what `POST /repos/{owner}/{repo}/dispatches` requires. It is already
  configured as an organisation secret.

Worth knowing: the deploy verification on the other side reads this application's commit from
`/static/VERSION_D`, which `scripts/sourceversion.py` generates at image build time — so that script
staying wired up in `docker.yml` is now load-bearing for confirming a deploy actually landed.

**Depends on** ufal/dspace-k8s#39, which defines the `deploy-ok-dspace` dispatch type. This PR is
inert until that merges.
