### PR TITLE
fix(roles): refresh UI after resricting collection item read

### DIFF
--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.spec.ts
@@ -26,12 +26,16 @@ describe('ComcolRoleComponent', () => {
   let comcolRole;
   let notificationsService;
 
-  const requestService = { hasByHref$: () => observableOf(true) };
+  const requestService = {
+    hasByHref$: () => observableOf(true),
+    setStaleByHrefSubstring: jasmine.createSpy('setStaleByHrefSubstring')
+  };
 
   const groupService = {
     findByHref: jasmine.createSpy('findByHref'),
     createComcolGroup: jasmine.createSpy('createComcolGroup').and.returnValue(observableOf({})),
-    deleteComcolGroup: jasmine.createSpy('deleteComcolGroup').and.returnValue(observableOf({}))
+    deleteComcolGroup: jasmine.createSpy('deleteComcolGroup').and.returnValue(observableOf({})),
+    clearGroupsRequests: jasmine.createSpy('clearGroupsRequests')
   };
 
   beforeEach(waitForAsync(() => {
@@ -153,6 +157,21 @@ describe('ComcolRoleComponent', () => {
 
       it('should call the groupService create method', (done) => {
         expect(groupService.createComcolGroup).toHaveBeenCalledWith(comp.dso, 'test role name', 'test role link');
+        done();
+      });
+    });
+
+    describe('when a group is created successfully', () => {
+      beforeEach(() => {
+        groupService.createComcolGroup.and.returnValue(createSuccessfulRemoteDataObject$({
+          id: '123',
+          name: 'TestGroup'
+        }));
+        comp.create();
+      });
+
+      it('should force a fresh GET after successful create', (done) => {
+        expect(groupService.findByHref).toHaveBeenCalledWith(comp.comcolRole.href, false, true);
         done();
       });
     });

--- a/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.ts
+++ b/src/app/shared/comcol/comcol-forms/edit-comcol-page/comcol-role/comcol-role.component.ts
@@ -4,7 +4,7 @@ import { Community } from '../../../../../core/shared/community.model';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { GroupDataService } from '../../../../../core/eperson/group-data.service';
 import { Collection } from '../../../../../core/shared/collection.model';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap, take } from 'rxjs/operators';
 import { getAllCompletedRemoteData, getFirstCompletedRemoteData } from '../../../../../core/shared/operators';
 import { RequestService } from '../../../../../core/data/request.service';
 import { RemoteData } from '../../../../../core/data/remote-data';
@@ -111,6 +111,9 @@ export class ComcolRoleComponent implements OnInit {
       if (rd.hasSucceeded) {
         this.groupService.clearGroupsRequests();
         this.requestService.setStaleByHrefSubstring(this.comcolRole.href);
+        this.groupService.findByHref(this.comcolRole.href, false, true)
+          .pipe(getFirstCompletedRemoteData(), take(1))
+          .subscribe();
       } else {
         this.notificationsService.error(
           this.roleName$.pipe(


### PR DESCRIPTION
## Problem description
When clicking **Restrict** on "Default item read access" in a collection's Assign Roles tab, the UI does not update – it still shows Anonymous + Restrict until the page is manually refreshed.

## Analysis
The `create()` method in `comcol-role.component.ts` POSTs to `/itemReadGroup` and the backend returns 201 with the new group. However, the frontend only marks the cached GET as stale – it does not force a new GET. The cache system stores only GET responses under the href; POST responses are not indexed as alternatives. As a result, the UI keeps showing the old cached "Anonymous" response.

The `delete()` method works correctly because after DELETE (204), it forces a new GET.

Fix: After a successful POST, force a fresh GET of `/itemReadGroup` with `useCachedVersionIfAvailable = false`.

### Copilot review
- [x] Requested review from Copilot